### PR TITLE
Add bonus checks from upstream

### DIFF
--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -3,7 +3,7 @@ from BaseClasses import Region
 from .items import PseudoregaliaItem, item_table, item_frequencies, item_groups
 from .locations import PseudoregaliaLocation, location_table
 from .regions import region_table
-from .options import pseudoregalia_options
+from .options import PseudoregaliaOptions
 from .rules_normal import PseudoregaliaNormalRules
 from .rules_hard import PseudoregaliaHardRules
 from .rules_expert import PseudoregaliaExpertRules
@@ -21,7 +21,8 @@ class PseudoregaliaWorld(World):
     locked_locations = {name: data for name, data in location_table.items() if data.locked_item}
     item_name_groups = item_groups
 
-    option_definitions = pseudoregalia_options
+    options_dataclass = PseudoregaliaOptions
+    options: PseudoregaliaOptions
 
     def create_item(self, name: str) -> PseudoregaliaItem:
         data = item_table[name]
@@ -73,12 +74,12 @@ class PseudoregaliaWorld(World):
 
     def fill_slot_data(self) -> Dict[str, Any]:
         return {"slot_number": self.player,
-                "death_link": bool(self.multiworld.death_link[self.player]),
-                "logic_level": self.multiworld.logic_level[self.player].value,
-                "obscure_logic": bool(self.multiworld.obscure_logic[self.player]),
-                "progressive_breaker": bool(self.multiworld.progressive_breaker[self.player]),
-                "progressive_slide": bool(self.multiworld.progressive_slide[self.player]),
-                "split_sun_greaves": bool(self.multiworld.split_sun_greaves[self.player]), }
+                "death_link": self.options.death_link.value,
+                "logic_level": self.options.logic_level.current_key,
+                "obscure_tricks": self.options.obscure_tricks.value,
+                "progressive_slide": self.options.progressive_slide.value,
+                "progressive_breaker": self.options.progressive_breaker.value,
+                "split_sun_greaves": self.options.split_sun_greaves.value, }
 
     def set_rules(self):
         difficulty = self.multiworld.logic_level[self.player]

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -24,28 +24,38 @@ class PseudoregaliaWorld(World):
     options_dataclass = PseudoregaliaOptions
     options: PseudoregaliaOptions
 
+    def get_filler_item_name(self):
+        return "Professionalism"  # TODO - make a real filler item lol
+
     def create_item(self, name: str) -> PseudoregaliaItem:
         data = item_table[name]
         return PseudoregaliaItem(name, data.classification, data.code, self.player)
 
     def create_items(self):
+        item_pool = []
         for item_name, item_data in item_table.items():
             if (item_name == "Dream Breaker"):
                 continue  # Really skrunkled way of just adding the one locked breaker to the pool for now.
-            if (item_data.code and item_data.can_create(self.multiworld, self.player)):
+            if (item_data.code and item_data.can_create(self)):
                 item_count = 1
                 if (item_name in item_frequencies):
                     item_count = item_frequencies[item_name]
                 for count in range(item_count):
-                    self.multiworld.itempool.append(
+                    item_pool.append(
                         PseudoregaliaItem(item_name, item_data.classification, item_data.code, self.player))
+
+        total_locations = len(self.multiworld.get_unfilled_locations(self.player))
+        created_item_count = len(item_pool)
+        assert created_item_count <= total_locations, "more locations need to be created; this is a dev issue"
+        item_pool += [self.create_filler() for _ in range(total_locations - created_item_count)]
+        self.multiworld.itempool += item_pool
 
     def create_regions(self):
         for region_name in region_table.keys():
             self.multiworld.regions.append(Region(region_name, self.player, self.multiworld))
 
         for loc_name, loc_data in location_table.items():
-            if not loc_data.can_create(self.multiworld, self.player):
+            if not loc_data.can_create(self):
                 continue
             region = self.multiworld.get_region(loc_data.region, self.player)
             new_loc = PseudoregaliaLocation(self.player, loc_name, loc_data.code, region)
@@ -59,7 +69,7 @@ class PseudoregaliaWorld(World):
 
         # Place locked locations.
         for location_name, location_data in self.locked_locations.items():
-            if not location_data.can_create(self.multiworld, self.player):
+            if not location_data.can_create(self):
                 continue
 
             # Doing this really stupidly because breaker's locking will change after logic rework is done
@@ -76,7 +86,7 @@ class PseudoregaliaWorld(World):
         return {"slot_number": self.player,
                 "death_link": self.options.death_link.value,
                 "logic_level": self.options.logic_level.current_key,
-                "obscure_tricks": self.options.obscure_tricks.value,
+                "obscure_logic": self.options.obscure_logic.value,
                 "progressive_slide": self.options.progressive_slide.value,
                 "progressive_breaker": self.options.progressive_breaker.value,
                 "split_sun_greaves": self.options.split_sun_greaves.value, }

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -41,7 +41,8 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         can_create=lambda world: not bool(world.options.progressive_breaker)),
     "Cling Gem": PseudoregaliaItemData(
         code=2365810008,
-        classification=ItemClassification.progression),
+        classification=ItemClassification.progression,
+        can_create=lambda world: not bool(world.options.split_gem)),
     "Ascendant Light": PseudoregaliaItemData(
         code=2365810009,
         classification=ItemClassification.progression),
@@ -111,6 +112,10 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         code=2365810028,
         classification=ItemClassification.progression,
         can_create=lambda world: bool(world.options.progressive_breaker)),
+    "Progressive Cling": PseudoregaliaItemData(
+        code=2365810029,
+        classification=ItemClassification.progression,
+        can_create=lambda world: bool(world.options.split_gem)),
 
     "Unlocked Door": PseudoregaliaItemData(
         classification=ItemClassification.useful),
@@ -127,6 +132,7 @@ item_frequencies = {
     "Health Piece": 16,
     "Progressive Slide": 2,
     "Air Kick": 4,
+    "Progressive Cling": 6,
     "Progressive Dream Breaker": 2,  # Will need to change this later when dream breaker stops being locked to vanilla
 }
 

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -112,7 +112,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         code=2365810028,
         classification=ItemClassification.progression,
         can_create=lambda world: bool(world.options.progressive_breaker)),
-    "Progressive Cling": PseudoregaliaItemData(
+    "Progressive Clings": PseudoregaliaItemData(
         code=2365810029,
         classification=ItemClassification.progression,
         can_create=lambda world: bool(world.options.split_gem)),
@@ -132,7 +132,7 @@ item_frequencies = {
     "Health Piece": 16,
     "Progressive Slide": 2,
     "Air Kick": 4,
-    "Progressive Cling": 6,
+    "Progressive Clings": 3,
     "Progressive Dream Breaker": 2,  # Will need to change this later when dream breaker stops being locked to vanilla
 }
 

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -9,36 +9,36 @@ class PseudoregaliaItem(Item):
 class PseudoregaliaItemData(NamedTuple):
     code: int = None
     classification: ItemClassification = ItemClassification.filler
-    can_create: Callable[[MultiWorld, int], bool] = lambda multiworld, player: True
+    can_create: Callable[[MultiWorld, int], bool] = lambda world: True
 
 
 item_table: Dict[str, PseudoregaliaItemData] = {
     "Dream Breaker": PseudoregaliaItemData(
         code=2365810001,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: not bool(multiworld.progressive_breaker[player])),
+        can_create=lambda world: not bool(world.options.progressive_breaker)),
     "Indignation": PseudoregaliaItemData(
         code=2365810002,
         classification=ItemClassification.useful),
     "Sun Greaves": PseudoregaliaItemData(
         code=2365810003,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: not bool(multiworld.split_sun_greaves[player])),
+        can_create=lambda world: not bool(world.options.split_sun_greaves)),
     "Slide": PseudoregaliaItemData(
         code=2365810004,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: not bool(multiworld.progressive_slide[player])),
+        can_create=lambda world: not bool(world.options.progressive_slide)),
     "Solar Wind": PseudoregaliaItemData(
         code=2365810005,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: not bool(multiworld.progressive_slide[player])),
+        can_create=lambda world: not bool(world.options.progressive_slide)),
     "Sunsetter": PseudoregaliaItemData(
         code=2365810006,
         classification=ItemClassification.progression),
     "Strikebreak": PseudoregaliaItemData(
         code=2365810007,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: not bool(multiworld.progressive_breaker[player])),
+        can_create=lambda world: not bool(world.options.progressive_breaker)),
     "Cling Gem": PseudoregaliaItemData(
         code=2365810008,
         classification=ItemClassification.progression),
@@ -48,12 +48,12 @@ item_table: Dict[str, PseudoregaliaItemData] = {
     "Soul Cutter": PseudoregaliaItemData(
         code=2365810010,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: not bool(multiworld.progressive_breaker[player])),
+        can_create=lambda world: not bool(world.options.progressive_breaker)),
 
     "Heliacal Power": PseudoregaliaItemData(
         code=2365810011,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: not bool(multiworld.split_sun_greaves[player])),
+        can_create=lambda world: not bool(world.options.split_sun_greaves)),
     "Aerial Finesse": PseudoregaliaItemData(
         code=2365810012,
         classification=ItemClassification.filler),
@@ -102,15 +102,15 @@ item_table: Dict[str, PseudoregaliaItemData] = {
     "Progressive Slide": PseudoregaliaItemData(
         code=2365810026,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: bool(multiworld.progressive_slide[player])),
+        can_create=lambda world: bool(world.options.progressive_slide)),
     "Air Kick": PseudoregaliaItemData(
         code=2365810027,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: bool(multiworld.split_sun_greaves[player])),
+        can_create=lambda world: bool(world.options.split_sun_greaves)),
     "Progressive Dream Breaker": PseudoregaliaItemData(
         code=2365810028,
         classification=ItemClassification.progression,
-        can_create=lambda multiworld, player: bool(multiworld.progressive_breaker[player])),
+        can_create=lambda world: bool(world.options.progressive_breaker)),
 
     "Unlocked Door": PseudoregaliaItemData(
         classification=ItemClassification.useful),

--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -9,7 +9,7 @@ class PseudoregaliaLocation(Location):
 class PseudoregaliaLocationData(NamedTuple):
     region: str
     code: int = None
-    can_create: Callable[[MultiWorld, int], bool] = lambda multiworld, player: True
+    can_create: Callable[[MultiWorld, int], bool] = lambda world: True
     locked_item: Optional[str] = None
     show_in_spoiler: bool = True
 
@@ -103,7 +103,7 @@ location_table = {
     "Listless Library - Sun Greaves": PseudoregaliaLocationData(
         code=2365810026,
         region="Library Greaves",
-        can_create=lambda multiworld, player: not bool(multiworld.split_sun_greaves[player])),
+        can_create=lambda world: not bool(world.options.split_sun_greaves)),
     "Listless Library - Upper Back": PseudoregaliaLocationData(
         code=2365810027,
         region="Library Top",),
@@ -181,19 +181,305 @@ location_table = {
         code=2365810050,
         region="The Great Door",),
 
+    # Split Greaves
     "Listless Library - Sun Greaves 1": PseudoregaliaLocationData(
         code=2365810051,
         region="Library Greaves",
-        can_create=lambda multiworld, player: bool(multiworld.split_sun_greaves[player])),
+        can_create=lambda world: bool(world.options.split_sun_greaves)),
     "Listless Library - Sun Greaves 2": PseudoregaliaLocationData(
         code=2365810052,
         region="Library Greaves",
-        can_create=lambda multiworld, player: bool(multiworld.split_sun_greaves[player])),
+        can_create=lambda world: bool(world.options.split_sun_greaves)),
     "Listless Library - Sun Greaves 3": PseudoregaliaLocationData(
         code=2365810053,
         region="Library Greaves",
-        can_create=lambda multiworld, player: bool(multiworld.split_sun_greaves[player])),
+        can_create=lambda world: bool(world.options.split_sun_greaves)),
 
+    # Goatlings
+    "Dilapidated Dungeon - the goatling who fell out his cage": PseudoregaliaLocationData(
+        code=2365810054,
+        region="Dungeon Mirror",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Castle Sansa - the goatling lamenting the skill issue of players who need a map": PseudoregaliaLocationData(
+        code=2365810055,
+        region="Castle Main",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Castle Sansa - the goatling who wants to lick the checkpoint": PseudoregaliaLocationData(
+        code=2365810056,
+        region="Castle Main",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Castle Sansa - the goatling who wanted to see the armour display": PseudoregaliaLocationData(
+        code=2365810057,
+        region="Castle Main",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Castle Sansa - the goatling about to jump into the haze": PseudoregaliaLocationData(
+        code=2365810058,
+        region="Castle By Scythe Corridor",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Any(&[ // Just need to break the wall.. nothing new
+    #    Powerup(A::DreamBreaker),
+    #    All(&[
+    #        Powerup(A::Sunsetter),
+    #        Trick(T::Knowledge, D::Normal),
+    #    ])
+    #]),
+    "Castle Sansa - the goatling that calls you bubble girl": PseudoregaliaLocationData(
+        code=2365810059,
+        region="Castle Main",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Any(&[
+    #    Powerup(A::HeliacalPower),
+    #    Powerup(A::ClingGem(4)),
+    #]),
+    "Castle Sansa - the goatling in the gazebo": PseudoregaliaLocationData(
+        code=2365810060,
+        region="Castle Main",  # TODO double check
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Sansa Keep - the goatling sad about the lack of furniture": PseudoregaliaLocationData(
+        code=2365810061,
+        region="Keep Main",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Sansa Keep - the goatling collapsing out of reality": PseudoregaliaLocationData(
+        code=2365810062,
+        region="Keep => Underbelly",  # pretty sure this is logically sound but should probably change
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Empty Bailey - the goatling who's hiding": PseudoregaliaLocationData(
+        code=2365810063,
+        region="Empty Bailey",  # TODO don't know of this is right
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Powerup(A::Slide), // Theres another way to get TO the item, not putting it in since its a one way unless it is slide though...
+    "Twilight Theatre - the goatling who can eat 20 beans at least": PseudoregaliaLocationData(
+        code=2365810064,
+        region="Castle => Theatre (Front)",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Twilight Theatre - the goatling who thought the theatre was safe": PseudoregaliaLocationData(
+        code=2365810065,
+        region="Castle => Theatre (Front)",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Twilight Theatre - the first goatling who really wanted to see the show": PseudoregaliaLocationData(
+        code=2365810066,
+        region="Castle => Theatre (Front)",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Twilight Theatre - the second goatling who really wanted to see the show": PseudoregaliaLocationData(
+        code=2365810067,
+        region="Castle => Theatre (Front)",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Lock::None,
+    "Twilight Theatre - the goatling that will kill again": PseudoregaliaLocationData(
+        code=2365810068,
+        region="Theatre Main",
+        can_create=lambda world: bool(world.options.shuffle_goatlings)),
+    #Any(&[
+    #    All(&[Powerup(A::SolarWind), Powerup(A::HeliacalPower)]),
+    #    Powerup(A::SunGreaves),
+    #    Powerup(A::ClingGem(6))
+    #]),
+
+    # Notes
+    "Listless Library - the note next to the egg nest": PseudoregaliaLocationData(
+        code=2365810069,
+        region="Library Main", # location: L::MainLibrary,
+        can_create=lambda world: bool(world.options.shuffle_notes)),
+    # locks: Any(&[
+    #     Powerup(A::SunGreaves),
+    #     Powerup(A::ClingGem(4)),
+    #     Powerup(A::SolarWind),
+    # ]),
+
+    "The Underbelly - the note on a high ledge in the big room": PseudoregaliaLocationData(
+        code=2365810070,
+        region="Underbelly Main Upper",  # location: L::MainUnderbelly,
+        # TODO: double check this region
+        can_create=lambda world: bool(world.options.shuffle_notes)),
+    # locks: All(&[ // Leaving as is for now.
+    #     Powerup(A::HeliacalPower),
+    #     Powerup(A::Sunsetter),
+    #     Any(&[
+    #         Powerup(A::ClingGem(6)),
+    #         Powerup(A::SunGreaves),
+    #         Powerup(A::SolarWind),
+    #     ]),
+    # ]),
+
+    "The Underbelly - the note behind the locked door": PseudoregaliaLocationData(
+        code=2365810071,
+        region="Underbelly By Heliacal",  # location: L::HpSave,
+        can_create=lambda world: bool(world.options.shuffle_notes)),
+    # locks: Lock::SmallKey,
+
+    "The Underbelly - the note near the empty bailey entrance": PseudoregaliaLocationData(
+        code=2365810072,
+        region="Underbelly Main Lower",  # location: L::BaileyHole,
+        can_create=lambda world: bool(world.options.shuffle_notes)),
+    # locks: Any(&[
+    #     Powerup(A::SunGreaves),
+    #     All(&[Powerup(A::HeliacalPower), Powerup(A::Sunsetter)]),
+    #     Powerup(A::ClingGem(6)),
+    #     Powerup(A::AscendantLight),
+    #     Powerup(A::SolarWind),
+    #     All(&[Powerup(A::HeliacalPower), Trick(T::ReverseKick, D::Normal)]),
+    #     All(&[Powerup(A::Sunsetter), Trick(T::Movement, D::Normal)]),
+    # ]),
+
+    # Chairs
+    "Castle Sansa - first chair next to the goatling who wants to lick the checkpoint": PseudoregaliaLocationData(
+        code=2365810073,
+        region="Castle Main",  # location: L::CsMain,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks: Lock::None,
+
+    "Castle Sansa - second chair next to the goatling who wants to lick the checkpoint": PseudoregaliaLocationData(
+        code=2365810074,
+        region="Castle Main",  # location: L::CsMain,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks: Lock::None,
+
+    "Castle Sansa - third chair next to the goatling who wants to lick the checkpoint": PseudoregaliaLocationData(
+        code=2365810075,
+        region="Castle Main",  # location: L::CsMain,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks: Lock::None,
+
+    "Castle Sansa - the chair in the gazebo": PseudoregaliaLocationData(
+        code=2365810076,
+        region="Castle Main",  # location: L::CsMain,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks: Lock::None,
+
+    "Listless Library - the chair at the entrance": PseudoregaliaLocationData(
+        code=2365810077,
+        region="Library Main",  # location: L::MainLibrary,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks: Lock::None,
+
+    "Listless Library - the chair after the normal sun greaves location": PseudoregaliaLocationData(
+        code=2365810078,
+        region="Library Greaves",  # location: L::LibSaveNearGreaves,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks: Lock::None,
+
+    "Listless Library - the chair next to the egg nest": PseudoregaliaLocationData(
+        code=2365810079,
+        region="Library Main",  # location: L::MainLibrary,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks: Any(&[
+    #     Powerup(A::SunGreaves),
+    #     Powerup(A::ClingGem(4)),
+    #     Powerup(A::SolarWind),
+    # ]),
+
+    "Sansa Keep - the chair collapsing out of reality": PseudoregaliaLocationData(
+        code=2365810080,
+        region="Keep => Underbelly",  # location: L::SkCastleRampEntry,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks: Lock::None,
+
+    "Sansa Keep - the chair in the middle of the parkour": PseudoregaliaLocationData(
+        code=2365810081,
+        region="Keep Main",  # location: L::SansaKeep,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks:  Any(&[
+    #     All(&[
+    #         Powerup(A::AscendantLight),
+    #         Any(&[
+    #             All(&[
+    #                 Powerup(A::ClingGem(4)),
+    #                 Any(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
+    #             ]),
+    #             All(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
+    #         ]),
+    #     ]),
+    #     All(&[
+    #         Powerup(A::DreamBreaker),
+    #         Powerup(A::Slide),
+    #         Powerup(A::SolarWind),
+    #         Powerup(A::Sunsetter),
+    #         Powerup(A::ClingGem(2)),
+    #         Powerup(A::SunGreaves),
+    #     ]),
+    # ]),
+
+    "Twilight Theatre - first chair around the table": PseudoregaliaLocationData(
+        code=2365810082,
+        region="Theatre Main",  # location: L::OtherTheatrePath,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # TODO may need additional logic
+    # locks: Lock::None,
+
+    "Twilight Theatre - second chair around the table": PseudoregaliaLocationData(
+        code=2365810083,
+        region="Theatre Main",  # location: L::OtherTheatrePath,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # TODO may need additional logic
+    # locks: Lock::None,
+
+    "Twilight Theatre - third chair around the table": PseudoregaliaLocationData(
+        code=2365810084,
+        region="Theatre Main",  # location: L::OtherTheatrePath,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # TODO may need additional logic
+    # locks: Lock::None,
+
+    "Twilight Theatre - the chair next to the books": PseudoregaliaLocationData(
+        code=2365810085,
+        region="Theatre Main",  # location: L::OtherTheatrePath,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # TODO may need additional logic
+    # locks: Lock::None,
+
+    "Twilight Theatre - the chair near the courtyard": PseudoregaliaLocationData(
+        code=2365810086,
+        region="Theatre Main",  # location: L::MainTheatre,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # TODO may need additional logic
+    # locks: Any(&[
+    #     Powerup(A::ClingGem(4)),
+    #     All(&[Powerup(A::SolarWind), Powerup(A::HeliacalPower), Powerup(A::SunGreaves)]),
+    # ]),
+
+    "Twilight Theatre - the chair in the soul cutter zone": PseudoregaliaLocationData(
+        code=2365810087,
+        region="Theatre Main",  # location: L::MainTheatre,
+        can_create=lambda world: bool(world.options.shuffle_chairs)),
+    # locks:  All(&[
+    #     Powerup(A::Strikebreak),
+    #     Powerup(A::ClingGem(6)),
+    #     Any(&[
+    #         // Logic for soul cutter route w/o soulcutter
+    #         All(&[
+    #             Powerup(A::Strikebreak),
+    #             Powerup(A::SolarWind),
+    #             Powerup(A::HeliacalPower),
+    #             Powerup(A::SunGreaves),
+    #             Powerup(A::Sunsetter),
+    #             Trick(T::ClingAbuse, D::Expert),
+    #             Trick(T::OneWall, D::Expert),
+    #             Trick(T::Movement, D::Insane),
+    #             Trick(T::Momentum, D::Expert),
+    #         ]),
+    #         //with soul cutter.
+    #         All(&[
+    #             Powerup(A::SoulCutter),
+    #             Any(&[
+    #                 Powerup(A::HeliacalPower),
+    #                 Powerup(A::SolarWind)
+    #             ]),
+    #         ]),
+    #     ]),
+    # ]),
+
+
+    # Door Unlocks
     "Dilapidated Dungeon - Unlock Door": PseudoregaliaLocationData(
         region="Dungeon Strong Eyes",
         locked_item="Unlocked Door",
@@ -223,6 +509,7 @@ location_table = {
         locked_item="Unlocked Door",
         show_in_spoiler=False),
 
+    # Victory Location
     "D S T RT ED M M O   Y": PseudoregaliaLocationData(
         region="The Great Door",
         locked_item="Something Worth Being Awake For"),

--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -209,18 +209,6 @@ location_table = {
         code=2365810090,
         region="Tower Remains",
         can_create=lambda world: bool(world.options.split_gem)),
-    "Tower Remains - Cling Gem 4": PseudoregaliaLocationData(
-        code=2365810091,
-        region="Tower Remains",
-        can_create=lambda world: bool(world.options.split_gem)),
-    "Tower Remains - Cling Gem 5": PseudoregaliaLocationData(
-        code=2365810092,
-        region="Tower Remains",
-        can_create=lambda world: bool(world.options.split_gem)),
-    "Tower Remains - Cling Gem 6": PseudoregaliaLocationData(
-        code=2365810093,
-        region="Tower Remains",
-        can_create=lambda world: bool(world.options.split_gem)),
 
     # Goatlings
     "Dilapidated Dungeon - the goatling who fell out his cage": PseudoregaliaLocationData(

--- a/AP_Randomizer/apworld/locations.py
+++ b/AP_Randomizer/apworld/locations.py
@@ -176,7 +176,8 @@ location_table = {
 
     "Tower Remains - Cling Gem": PseudoregaliaLocationData(
         code=2365810049,
-        region="Tower Remains"),
+        region="Tower Remains",
+        can_create=lambda world: not bool(world.options.split_gem)),
     "Tower Remains - Atop The Tower": PseudoregaliaLocationData(
         code=2365810050,
         region="The Great Door",),
@@ -194,6 +195,32 @@ location_table = {
         code=2365810053,
         region="Library Greaves",
         can_create=lambda world: bool(world.options.split_sun_greaves)),
+
+    # Split Gem
+    "Tower Remains - Cling Gem 1": PseudoregaliaLocationData(
+        code=2365810088,
+        region="Tower Remains",
+        can_create=lambda world: bool(world.options.split_gem)),
+    "Tower Remains - Cling Gem 2": PseudoregaliaLocationData(
+        code=2365810089,
+        region="Tower Remains",
+        can_create=lambda world: bool(world.options.split_gem)),
+    "Tower Remains - Cling Gem 3": PseudoregaliaLocationData(
+        code=2365810090,
+        region="Tower Remains",
+        can_create=lambda world: bool(world.options.split_gem)),
+    "Tower Remains - Cling Gem 4": PseudoregaliaLocationData(
+        code=2365810091,
+        region="Tower Remains",
+        can_create=lambda world: bool(world.options.split_gem)),
+    "Tower Remains - Cling Gem 5": PseudoregaliaLocationData(
+        code=2365810092,
+        region="Tower Remains",
+        can_create=lambda world: bool(world.options.split_gem)),
+    "Tower Remains - Cling Gem 6": PseudoregaliaLocationData(
+        code=2365810093,
+        region="Tower Remains",
+        can_create=lambda world: bool(world.options.split_gem)),
 
     # Goatlings
     "Dilapidated Dungeon - the goatling who fell out his cage": PseudoregaliaLocationData(

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -63,6 +63,27 @@ class SplitSunGreaves(Toggle):
     display_name = "Split Sun Greaves"
 
 
+class ShuffleGoatlings(Toggle):
+    """
+    Adds Goatlings to the location pool.
+    """
+    display_name = "Shuffle Goatlings"
+
+
+class ShuffleNotes(Toggle):
+    """
+    Adds Notes to the location pool.
+    """
+    display_name = "Shuffle Notes"
+
+
+class ShuffleChairs(Toggle):
+    """
+    Adds Chairs to the location pool.
+    """
+    display_name = "Shuffle Chairs"
+
+
 @dataclass
 class PseudoregaliaOptions(PerGameCommonOptions):
     logic_level: LogicLevel
@@ -70,4 +91,7 @@ class PseudoregaliaOptions(PerGameCommonOptions):
     progressive_breaker: ProgressiveBreaker
     progressive_slide: ProgressiveSlide
     split_sun_greaves: SplitSunGreaves
+    shuffle_goatlings: ShuffleGoatlings
+    shuffle_notes: ShuffleNotes
+    shuffle_chairs: ShuffleChairs
     death_link: DeathLink

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -65,7 +65,7 @@ class SplitSunGreaves(Toggle):
 
 class SplitClingGem(Toggle):
     """
-    Replaces Cling Gem with four individual Progressive Gems.
+    Replaces Cling Gem with three individual Progressive Gems that have two clings each.
     """
     display_name = "Split Cling Gem"
 

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -63,6 +63,13 @@ class SplitSunGreaves(Toggle):
     display_name = "Split Sun Greaves"
 
 
+class SplitClingGem(Toggle):
+    """
+    Replaces Cling Gem with four individual Progressive Gems.
+    """
+    display_name = "Split Cling Gem"
+
+
 class ShuffleGoatlings(Toggle):
     """
     Adds Goatlings to the location pool.
@@ -91,6 +98,7 @@ class PseudoregaliaOptions(PerGameCommonOptions):
     progressive_breaker: ProgressiveBreaker
     progressive_slide: ProgressiveSlide
     split_sun_greaves: SplitSunGreaves
+    split_gem: SplitClingGem
     shuffle_goatlings: ShuffleGoatlings
     shuffle_notes: ShuffleNotes
     shuffle_chairs: ShuffleChairs

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -1,4 +1,5 @@
-from Options import Toggle, Choice, DefaultOnToggle, DeathLink
+from dataclasses import dataclass
+from Options import Toggle, Choice, DefaultOnToggle, DeathLink, PerGameCommonOptions
 from .constants.difficulties import NORMAL, HARD, EXPERT, LUNATIC
 
 
@@ -62,11 +63,11 @@ class SplitSunGreaves(Toggle):
     display_name = "Split Sun Greaves"
 
 
-pseudoregalia_options = {
-    "logic_level": LogicLevel,
-    "obscure_logic": ObscureLogic,
-    "progressive_breaker": ProgressiveBreaker,
-    "progressive_slide": ProgressiveSlide,
-    "split_sun_greaves": SplitSunGreaves,
-    "death_link": DeathLink,
-}
+@dataclass
+class PseudoregaliaOptions(PerGameCommonOptions):
+    logic_level: LogicLevel
+    obscure_logic: ObscureLogic
+    progressive_breaker: ProgressiveBreaker
+    progressive_slide: ProgressiveSlide
+    split_sun_greaves: SplitSunGreaves
+    death_link: DeathLink

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -80,6 +80,276 @@ class PseudoregaliaRulesHelpers:
             "Tower Remains - Atop The Tower": lambda state: True,
         }
 
+        if world.options.shuffle_goatlings:
+            self.location_rules.update({
+                # Goatlings
+                # "Dilapidated Dungeon - the goatling who fell out his cage":
+                # #Lock::None,
+                # "Castle Sansa - the goatling lamenting the skill issue of players who need a map":
+                # #Lock::None,
+                # "Castle Sansa - the goatling who wants to lick the checkpoint":
+                # #Lock::None,
+                # "Castle Sansa - the goatling who wanted to see the armour display":
+                # #Lock::None,
+                "Castle Sansa - the goatling about to jump into the haze": lambda state:
+                    self.has_breaker(state)
+                    or (self.has_plunge(state)
+                        and self.trick("Knowledge", "Normal")),  # TODO double check this is equivilant
+                # Any(&[ // Just need to break the wall.. nothing new
+                #     Powerup(A::DreamBreaker),
+                #     All(&[
+                #         Powerup(A::Sunsetter),
+                #         Trick(T::Knowledge, D::Normal),
+                #     ])
+                # ]),
+                "Castle Sansa - the goatling that calls you bubble girl": lambda state:
+                    self.get_kicks(state, 1)
+                    or self.has_gem(state, 4),
+                # Any(&[
+                #     Powerup(A::HeliacalPower),
+                #     Powerup(A::ClingGem(4)),
+                # ]),
+                #  "Castle Sansa - the goatling in the gazebo":
+                #  #Lock::None,
+                #  "Sansa Keep - the goatling sad about the lack of furniture":
+                #  #Lock::None,
+                #  "Sansa Keep - the goatling collapsing out of reality":
+                #  #Lock::None,
+                "Empty Bailey - the goatling who's hiding": lambda state:
+                    self.has_slide(state),
+                # Powerup(A::Slide), // Theres another way to get TO the item, not putting it in since its a one way unless it is slide though...
+                #  "Twilight Theatre - the goatling who can eat 20 beans at least":
+                #  #Lock::None,
+                #  "Twilight Theatre - the goatling who thought the theatre was safe":
+                #  #Lock::None,
+                #  "Twilight Theatre - the first goatling who really wanted to see the show":
+                #  #Lock::None,
+                #  "Twilight Theatre - the second goatling who really wanted to see the show":
+                #  #Lock::None,
+                "Twilight Theatre - the goatling that will kill again": lambda state:
+                    any([
+                        self.can_slidejump(state) and self.get_kicks(state, 1),
+                        self.get_kicks(state, 3),
+                        self.has_gem(state, 6),
+                        ]),
+                # Any(&[
+                #     All(&[Powerup(A::SolarWind), Powerup(A::HeliacalPower)]),
+                #     Powerup(A::SunGreaves),
+                #     Powerup(A::ClingGem(6))
+                # ]),
+            })
+
+        if world.options.shuffle_chairs:
+            self.location_rules.update({
+                # Chairs
+                # "Castle Sansa - first chair next to the goatling who wants to lick the checkpoint":
+                # # locks: Lock::None,
+                # "Castle Sansa - second chair next to the goatling who wants to lick the checkpoint":
+                # # locks: Lock::None,
+                # "Castle Sansa - third chair next to the goatling who wants to lick the checkpoint":
+                # # locks: Lock::None,
+                # "Castle Sansa - the chair in the gazebo":
+                # # locks: Lock::None,
+                # "Listless Library - the chair at the entrance":
+                # # locks: Lock::None,
+                # "Listless Library - the chair after the normal sun greaves location":
+                # # locks: Lock::None,
+                "Listless Library - the chair next to the egg nest": lambda state:
+                    any([
+                        self.get_kicks(state, 3),
+                        self.has_gem(state, 4),
+                        self.can_slidejump(state)
+                        ]),
+                # locks: Any(&[
+                #     Powerup(A::SunGreaves),
+                #     Powerup(A::ClingGem(4)),
+                #     Powerup(A::SolarWind),
+                # ]),
+
+                # "Sansa Keep - the chair collapsing out of reality":
+                # # locks: Lock::None,
+
+                "Sansa Keep - the chair in the middle of the parkour": lambda state:
+                    any([
+                        all([
+                            self.can_bounce(state),
+                            any([
+                                all([
+                                    self.has_gem(state, 4),
+                                    any([self.has_plunge(state), self.get_kicks(state, 3)]),
+                                    ]),
+                                all([self.has_plunge(state), self.get_kicks(state, 3)])
+                                ]),
+                            ]),
+                        all([
+                            self.has_breaker(state),
+                            self.has_slide(state),
+                            self.can_slidejump(state),
+                            self.has_plunge(state),
+                            self.has_gem(state, 2),
+                            self.get_kicks(state, 3),
+                            ])
+                        ]),
+                # locks:  Any(&[
+                #     All(&[
+                #         Powerup(A::AscendantLight),
+                #         Any(&[
+                #             All(&[
+                #                 Powerup(A::ClingGem(4)),
+                #                 Any(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
+                #             ]),
+                #             All(&[Powerup(A::Sunsetter), Powerup(A::SunGreaves)]),
+                #         ]),
+                #     ]),
+                #     All(&[
+                #         Powerup(A::DreamBreaker),
+                #         Powerup(A::Slide),
+                #         Powerup(A::SolarWind),
+                #         Powerup(A::Sunsetter),
+                #         Powerup(A::ClingGem(2)),
+                #         Powerup(A::SunGreaves),
+                #     ]),
+                # ]),
+
+                # "Twilight Theatre - first chair around the table":
+                # # TODO may need additional logic
+                # # locks: Lock::None,
+                # "Twilight Theatre - second chair around the table":
+                # # TODO may need additional logic
+                # # locks: Lock::None,
+                # "Twilight Theatre - third chair around the table":
+                # # TODO may need additional logic
+                # # locks: Lock::None,
+                # "Twilight Theatre - the chair next to the books":
+                # # TODO may need additional logic
+                # # locks: Lock::None,
+                "Twilight Theatre - the chair near the courtyard": lambda state:
+                    any([
+                        self.has_gem(state, 4),
+                        all([self.can_slidejump(state), self.get_kicks(state, 4)]),
+                    ]),
+                # TODO may need additional logic
+                # locks: Any(&[
+                #     Powerup(A::ClingGem(4)),
+                #     All(&[Powerup(A::SolarWind), Powerup(A::HeliacalPower), Powerup(A::SunGreaves)]),
+                # ]),
+
+                "Twilight Theatre - the chair in the soul cutter zone": lambda state:
+                    all([
+                        self.can_strikebreak(state),
+                        self.has_gem(state, 6),
+                        any([
+                            all([
+                                self.can_strikebreak(state),
+                                self.can_slidejump(state),
+                                self.get_kicks(state, 4),
+                                self.has_plunge(state),
+                                self.trick("ClingAbuse", "Expert"),
+                                self.trick("OneWall", "Expert"),
+                                self.trick("Movement", "Insane"),
+                                self.trick("Momentum", "Expert"),
+                            ]),
+                            all([
+                                self.can_soulcutter(state),
+                                any([
+                                    self.get_kicks(state, 1),
+                                    self.can_slidejump(state),
+                                ]),
+                            ]),
+                        ]),
+                    ]),
+                # locks:  All(&[
+                #     Powerup(A::Strikebreak),
+                #     Powerup(A::ClingGem(6)),
+                #     Any(&[
+                #         // Logic for soul cutter route w/o soulcutter
+                #         All(&[
+                #             Powerup(A::Strikebreak),
+                #             Powerup(A::SolarWind),
+                #             Powerup(A::HeliacalPower),
+                #             Powerup(A::SunGreaves),
+                #             Powerup(A::Sunsetter),
+                #             Trick(T::ClingAbuse, D::Expert),
+                #             Trick(T::OneWall, D::Expert),
+                #             Trick(T::Movement, D::Insane),
+                #             Trick(T::Momentum, D::Expert),
+                #         ]),
+                #         //with soul cutter.
+                #         All(&[
+                #             Powerup(A::SoulCutter),
+                #             Any(&[
+                #                 Powerup(A::HeliacalPower),
+                #                 Powerup(A::SolarWind)
+                #             ]),
+                #         ]),
+                #     ]),
+                # ]),
+            })
+
+        if world.options.shuffle_notes:
+            self.location_rules.update({
+                # Notes
+                "Listless Library - the note next to the egg nest": lambda state:
+                    any([
+                        self.get_kicks(state, 3),
+                        self.has_gem(state, 4),
+                        self.can_slidejump(state),
+                    ]),
+                # locks: Any(&[
+                #     Powerup(A::SunGreaves),
+                #     Powerup(A::ClingGem(4)),
+                #     Powerup(A::SolarWind),
+                # ]),
+
+                "The Underbelly - the note on a high ledge in the big room": lambda state:
+                    all([
+                        self.get_kicks(state, 1),
+                        self.has_plunge(state),
+                        any([
+                            self.has_gem(state, 4),
+                            self.get_kicks(state, 4),  # to account for the 1 already in the all clause
+                            self.can_slidejump(state),
+                        ]),
+                    ]),
+                # locks: All(&[ // Leaving as is for now.
+                #     Powerup(A::HeliacalPower),
+                #     Powerup(A::Sunsetter),
+                #     Any(&[
+                #         Powerup(A::ClingGem(6)),
+                #         Powerup(A::SunGreaves),
+                #         Powerup(A::SolarWind),
+                #     ]),
+                # ]),
+
+                "The Underbelly - the note behind the locked door": lambda state:
+                    self.has_small_keys(state),
+                # locks: Lock::SmallKey,
+
+                "The Underbelly - the note near the empty bailey entrance": lambda state:
+                    any([
+                        self.get_kicks(state, 3),
+                        all([self.get_kicks(state, 1), self.has_plunge(state)]),
+                        self.has_gem(state, 6),
+                        self.can_bounce(state),
+                        self.can_slidejump(state),
+                        all([self.get_kicks(state, 1), self.trick("ReverseKick", "Normal")]),
+                        all([self.has_plunge(state), self.trick("Movement", "Normal")]),
+                    ]),
+                # locks: Any(&[
+                #     Powerup(A::SunGreaves),
+                #     All(&[Powerup(A::HeliacalPower), Powerup(A::Sunsetter)]),
+                #     Powerup(A::ClingGem(6)),
+                #     Powerup(A::AscendantLight),
+                #     Powerup(A::SolarWind),
+                #     All(&[Powerup(A::HeliacalPower), Trick(T::ReverseKick, D::Normal)]),
+                #     All(&[Powerup(A::Sunsetter), Trick(T::Movement, D::Normal)]),
+                # ]),
+            })
+
+    def trick(self, category: str, difficullty: str):
+        # will eventually check self.world.options for the correct values
+        return True
+
     def has_breaker(self, state) -> bool:
         return state.has_any({"Dream Breaker", "Progressive Dream Breaker"}, self.player)
 
@@ -89,7 +359,8 @@ class PseudoregaliaRulesHelpers:
     def has_plunge(self, state) -> bool:
         return state.has("Sunsetter", self.player)
 
-    def has_gem(self, state) -> bool:
+    def has_gem(self, state, count: int = 6) -> bool:
+        # TODO update for split gem
         return state.has("Cling Gem", self.player)
 
     def can_bounce(self, state) -> bool:
@@ -142,7 +413,7 @@ class PseudoregaliaRulesHelpers:
                 or state.count("Progressive Dream Breaker", self.player) >= 3)
 
     def knows_obscure(self, state) -> bool:
-        return self.world.options.obscure_tricks.value
+        return self.world.options.obscure_logic.value
 
     def set_pseudoregalia_rules(self) -> None:
         multiworld = self.world.multiworld

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -142,8 +142,7 @@ class PseudoregaliaRulesHelpers:
                 or state.count("Progressive Dream Breaker", self.player) >= 3)
 
     def knows_obscure(self, state) -> bool:
-        """True when Obscure Logic is enabled, False when it isn't."""
-        raise Exception("knows_obscure() was not set")
+        return self.world.options.obscure_tricks.value
 
     def set_pseudoregalia_rules(self) -> None:
         multiworld = self.world.multiworld

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -89,13 +89,6 @@ class PseudoregaliaRulesHelpers:
                     self.get_kicks(state, 3),
                 "Tower Remains - Cling Gem 3": lambda state:
                     self.get_kicks(state, 3),
-                "Tower Remains - Cling Gem 4": lambda state:
-                    self.get_kicks(state, 3),
-                "Tower Remains - Cling Gem 5": lambda state:
-                    self.get_kicks(state, 3),
-                "Tower Remains - Cling Gem 6": lambda state:
-                    self.get_kicks(state, 3),
-
                 })
             del self.location_rules["Tower Remains - Cling Gem"]
 
@@ -382,7 +375,7 @@ class PseudoregaliaRulesHelpers:
         clings: int = 0
         if state.has("Cling Gem", self.player):
             clings += 6
-        clings += state.count("Progressive Cling", self.player)
+        clings += 2 * state.count("Progressive Clings", self.player)
         return clings >= count
 
     def can_bounce(self, state) -> bool:

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -80,6 +80,25 @@ class PseudoregaliaRulesHelpers:
             "Tower Remains - Atop The Tower": lambda state: True,
         }
 
+        # TODO unskrunkle
+        if world.options.split_gem:
+            self.location_rules.update({
+                "Tower Remains - Cling Gem 1": lambda state:
+                    self.get_kicks(state, 3),
+                "Tower Remains - Cling Gem 2": lambda state:
+                    self.get_kicks(state, 3),
+                "Tower Remains - Cling Gem 3": lambda state:
+                    self.get_kicks(state, 3),
+                "Tower Remains - Cling Gem 4": lambda state:
+                    self.get_kicks(state, 3),
+                "Tower Remains - Cling Gem 5": lambda state:
+                    self.get_kicks(state, 3),
+                "Tower Remains - Cling Gem 6": lambda state:
+                    self.get_kicks(state, 3),
+
+                })
+            del self.location_rules["Tower Remains - Cling Gem"]
+
         if world.options.shuffle_goatlings:
             self.location_rules.update({
                 # Goatlings

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -360,8 +360,11 @@ class PseudoregaliaRulesHelpers:
         return state.has("Sunsetter", self.player)
 
     def has_gem(self, state, count: int = 6) -> bool:
-        # TODO update for split gem
-        return state.has("Cling Gem", self.player)
+        clings: int = 0
+        if state.has("Cling Gem", self.player):
+            clings += 6
+        clings += state.count("Progressive Cling", self.player)
+        return clings >= count
 
     def can_bounce(self, state) -> bool:
         return self.has_breaker(state) and state.has("Ascendant Light", self.player)


### PR DESCRIPTION
adds goatlings, notes, chairs to apworld

needs some work for finalizing, mostly 
- game mod support,
- either an overhaul of options to align with standalone or a convert to ap options
- a proper filler item for when there are more locations than items in the pool
- ~~split gem to be implemented on an item side in order for some of the logic pieces to matter~~