### PR TITLE
rulebuilder branch: flush out logic.yaml

### DIFF
--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -1,5 +1,6 @@
 import pkgutil
 from typing import Any
+from collections import defaultdict
 import yaml
 
 from worlds.AutoWorld import World, WebWorld
@@ -48,8 +49,8 @@ class PseudoregaliaWorld(World):
     game = "Pseudoregalia"
     required_client_version = (0, 7, 0)
  
-    item_name_to_id = {name: data.code for name, data in item_table.items() if data.code is not None}
-    location_name_to_id = {name: data.code for name, data in location_table.items() if data.code is not None}
+    item_name_to_id = {name: 2365810000 + data.code for name, data in item_table.items() if data.code is not None}
+    location_name_to_id = {name: 2365810000 + data.code for name, data in location_table.items() if data.code is not None}
     item_name_groups = item_groups
 
     options_dataclass = PseudoregaliaOptions
@@ -60,7 +61,7 @@ class PseudoregaliaWorld(World):
     filler = ("Healing", "Magic Power")
     filler_index = 0
 
-    tags: dict[str, int] = {}
+    tags: dict[str, int]
 
     def create_key_hints(self) -> Any:
         key_hints = [[] for _ in range(5)]
@@ -102,14 +103,20 @@ class PseudoregaliaWorld(World):
         mapping = pseudoregalia_data.item_mapping[item.name]
         if isinstance(mapping, str):
             state.add_item(mapping, self.player)
+            if mapping in ("kick", "plunge"):
+                state.add_item("kick_or_plunge", self.player)
         elif isinstance(mapping, list):
             index = state.count(item.name, self.player)
             if index < len(mapping):
                 state.add_item(mapping[index], self.player)
+                if mapping[index] in ("kick", "plunge"):
+                    state.add_item("kick_or_plunge", self.player)
         elif isinstance(mapping, ItemMappingData):
             if mapping.max is None or state.count(item.name, self.player) < mapping.max:
                 count = mapping.count if mapping.count is not None else 1
                 state.add_item(mapping.name, self.player, count)
+                if mapping.name in ("kick", "plunge"):
+                    state.add_item("kick_or_plunge", self.player, count)
         return super().collect(state, item)
 
     def remove(self, state: CollectionState, item: PseudoregaliaItem) -> bool:
@@ -149,6 +156,7 @@ class PseudoregaliaWorld(World):
                 # start_with_breaker is forced on if otherwise player wouldn't have enough checks
                 self.options.start_with_breaker.value = 1
 
+        self.tags = defaultdict(lambda: 0)
         # TODO fill out self.tags based on player options
 
     def create_regions(self):

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -103,22 +103,16 @@ class PseudoregaliaWorld(World):
         mapping = pseudoregalia_data.item_mapping[item.name]
         if isinstance(mapping, str):
             state.add_item(mapping, self.player)
-            if mapping in ("kick", "plunge"):
-                state.add_item("kick_or_plunge", self.player)
         elif isinstance(mapping, list):
             index = state.count(item.name, self.player)
             if index < len(mapping):
                 state.add_item(mapping[index], self.player)
-                if mapping[index] in ("kick", "plunge"):
-                    state.add_item("kick_or_plunge", self.player)
         elif isinstance(mapping, ItemMappingData):
             first_only = mapping.first_only if mapping.first_only is not None else False
             if not first_only or state.count(item.name, self.player) == 0:
                 count = mapping.count if mapping.count is not None else 1
                 for name in mapping.names:
                     state.add_item(name, self.player, count)
-                    if name in ("kick", "plunge"):
-                        state.add_item("kick_or_plunge", self.player, count)
         return super().collect(state, item)
 
     def remove(self, state: CollectionState, item: PseudoregaliaItem) -> bool:

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -49,8 +49,8 @@ class PseudoregaliaWorld(World):
     game = "Pseudoregalia"
     required_client_version = (0, 7, 0)
  
-    item_name_to_id = {name: 2365810000 + data.code for name, data in item_table.items() if data.code is not None}
-    location_name_to_id = {name: 2365810000 + data.code for name, data in location_table.items() if data.code is not None}
+    item_name_to_id = {name: data.code for name, data in item_table.items() if data.code is not None}
+    location_name_to_id = {name: data.code for name, data in location_table.items() if data.code is not None}
     item_name_groups = item_groups
 
     options_dataclass = PseudoregaliaOptions
@@ -173,7 +173,8 @@ class PseudoregaliaWorld(World):
             if not check_options(self.options, loc_data.can_create):
                 continue
             region = self.get_region(loc_data.region)
-            new_loc = PseudoregaliaLocation(self.player, loc_data.name, loc_data.code, region)
+            loc_id = None if loc_data.code is None else 2365810000 + loc_data.code
+            new_loc = PseudoregaliaLocation(self.player, loc_data.name, loc_id, region)
             region.locations.append(new_loc)
             rule = pseudoregalia_rules.location_rules.get(loc_data.name)
             if rule is not None:

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -108,32 +108,32 @@ ref_rules:
         game_version: full_gold
     - ref: can_slide_jump
 - name: can_attack
-    rule:
-      or:
-      - has: breaker
-      - has: plunge
+  rule:
+    or:
+    - has: breaker
+    - has: plunge
+      tags:
+        plunge_attack: 1
+- name: can_unlock_door
+  rule:
+    and:
+    - ref: can_attack
+    - or:
+      - has:
+          small_key: 7
+      - has:
+          small_key: 6
         tags:
-          plunge_attack: 1
-  - name: can_unlock_door
-    rule:
-      and:
-      - ref: can_attack
-      - or:
-        - has:
-            small_key: 7
-        - has:
-            small_key: 6
-          tags:
-            smart_keys: 1
-  - name: can_enter_dark_rooms
-    rule:
-      or:
-      - has: light
-      - has: breaker
-        tags:
-          light_breaker: 1
-      - tags:
-          not_afraid_of_the_dark: 3
+          smart_keys: 1
+- name: can_enter_dark_rooms
+  rule:
+    or:
+    - has: light
+    - has: breaker
+      tags:
+        light_breaker: 1
+    - tags:
+        not_afraid_of_the_dark: 3
 
 regions:
   - name: Dungeon Mirror
@@ -210,11 +210,11 @@ regions:
           has:
             breaker: 1
             slide_jump: 1
-      - options:
-          game_version: map_patch
-          difficulty: expert
-        ref: can_attack
-        has: slide
+        - options:
+            game_version: map_patch
+            difficulty: expert
+          ref: can_attack
+          has: slide
   - name: Dungeon => Castle
     exits:
     - region: Dungeon Mirror
@@ -237,12 +237,12 @@ regions:
           has:
             breaker: 1
             cling: 2
-      - options:
-          game_version: map_patch
-          difficulty: expert
-        has:
-          breaker: 1
-          slide: 1
+        - options:
+            game_version: map_patch
+            difficulty: expert
+          has:
+            breaker: 1
+            slide: 1
     - region: Castle Main
       entrance_name: Dungeon Top Exit
   - name: Dungeon Escape Lower
@@ -306,7 +306,7 @@ regions:
             cling: 2
         - options:
             difficulty: hard
-          - has: kick
+          has: kick
         - options:
             difficulty: expert
           has: slide
@@ -366,7 +366,7 @@ regions:
             difficulty: hard
           tags:
             old_obscure: 1
-          reg: can_attack
+          ref: can_attack
           has: slide_jump
         - options:
             difficulty: expert
@@ -657,10 +657,11 @@ regions:
       # On Hard and above, the player is expected to not do either.
     - region: Keep Sunsetter
       rule:
-        has:
-          cling: 2
-          # See "Keep Main -> Keep Locked Room".
-          # All other methods would go through Keep Locked Room instead.
+        or:
+        - has:
+            cling: 2
+           # See "Keep Main -> Keep Locked Room".
+           # All other methods would go through Keep Locked Room instead.
         - options:
             difficulty: hard
     - region: Keep Throne Room
@@ -730,7 +731,7 @@ regions:
             breaker: 1
             light: 1
             kick_or_plunge: 3
-         - options:
+        - options:
             difficulty: expert
           has:
             breaker: 1
@@ -848,20 +849,20 @@ regions:
           has:
             kick: 2
             light: 1
-      - options:
-          game_version: map_patch
-          difficulty: expert
-        and:
-        - has: slide
-        - or:
-          - has: light
-          - has: kick
-          - has:
-              cling: 2
-      - options:
-          game_version: full_gold
-          difficulty: expert
-        has: slide
+        - options:
+            game_version: map_patch
+            difficulty: expert
+          and:
+          - has: slide
+          - or:
+            - has: light
+            - has: kick
+            - has:
+                cling: 2
+        - options:
+            game_version: full_gold
+            difficulty: expert
+          has: slide
 
   - name: Tower Remains
     exits:
@@ -2033,12 +2034,12 @@ locations:
           kick_or_plunge: 1
       - has:
           kick_or_plunge: 2
-        - options:
-            difficulty: hard
-          has:
-            cling: 4
-        - options:
-            difficulty: expert
+      - options:
+          difficulty: hard
+        has:
+          cling: 4
+      - options:
+          difficulty: expert
           has: slide
   - name: Listless Library - Locked Door Across
     code: 28

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -59,8 +59,7 @@ tags:
     expert: At this level, you may be required to use slide ultras for distance, which can require higher speed.
     lunatic: At this level, slide ultra setups may be very precise, involving very small runway or sharp angle changes.
   - name: old_obscure
-    off: obscure is not expected
-    on: obscure is expected
+    lunatic: At this level, all obscure tech in the previous format is expected
 
 tag_groups:
   - name: basic_tech
@@ -122,7 +121,7 @@ regions:
     - region: Dungeon Escape Lower
       rule:
         and:
-          - ref: dungeon_escape
+          #  - ref: dungeon_escape  # TODO: add this later
           - ref: can_attack
           - ref: can_enter_dark_rooms
       # keeping this version for reference, but keeping the assumptions about macros consistent
@@ -148,7 +147,7 @@ regions:
           options:
             game_version: map_patch
         - or:
-          - has: bounce
+          - has: light
           - ref: can_attack
             has:
               kick: 2
@@ -180,7 +179,7 @@ regions:
     - region: Dungeon Escape Upper
       rule:
         or:
-        - has: bounce
+        - has: light
         - has:
             kick: 1
             plunge: 1
@@ -193,7 +192,7 @@ regions:
     - region: Theatre Outside Scythe Corridor
       rule:
         or:
-        - has: bounce
+        - has: light
         - has: kick
         - has:
             cling: 2
@@ -322,7 +321,8 @@ regions:
         or:
         - has:
             kick_or_plunge: 4
-        - ref: obscure_tech
+        - tags:
+            old_obscure: 1
           has:
             kick: 1
             plunge: 1
@@ -354,7 +354,7 @@ regions:
             plunge: 1
         - has:
             kick: 3
-            bounce: 1
+            light: 1
   - name: Library Back
     exits:
     - region: Library Greaves
@@ -411,12 +411,12 @@ regions:
                   kick: 1
               - has:
                   plunge: 1
-                  bounce: 1
+                  light: 1
               - has:
                   kick: 1
-                  bounce: 1
+                  light: 1
         - has:
-            bounce: 1
+            light: 1
             kick_or_plunge: 4
     - region: Keep => Underbelly
       rule:
@@ -430,9 +430,10 @@ regions:
         - has:
             cling: 2
         - has: kick
-        - has: bounce
+        - has: light
         - has: slide_jump
-        - ref: obscure_tech
+        - tags:
+            old_obscure: 1
           has: plunge  # TODO: this doesn't really matter right now but is a little questionable for normal
     - region: Keep (Northeast) => Castle
       rule:
@@ -489,7 +490,7 @@ regions:
             has:
               kick: 1
               plunge: 1
-              bounce: 1
+              light: 1
         - or: # get onto the bridge
           - has: slide_jump
           - has: plunge
@@ -513,7 +514,7 @@ regions:
     - region: Underbelly Ascendant Light
       rule:
         or:
-        - has: bounce
+        - has: light
         - has:
             cling: 2
             kick: 1
@@ -523,7 +524,8 @@ regions:
             kick: 1
             slide_jump: 1
         - and:
-          - ref: obscure_tech
+          - tags:
+              old_obscure: 1
           - ref: can_attack
   - name: Underbelly Light Pillar
     exits:
@@ -531,7 +533,7 @@ regions:
     - region: Underbelly => Dungeon
       rule:
         or:
-        - has: bounce
+        - has: light
         - has:
             kick_or_plunge: 4
     - region: Underbelly Ascendant Light
@@ -552,7 +554,7 @@ regions:
     - region: Underbelly => Dungeon
       rule:
         or:
-        - has: bounce
+        - has: light
         - has:
             cling: 2
         - has:
@@ -578,7 +580,8 @@ regions:
           plunge: 1
     - region: Underbelly Main Upper
       rule:
-        ref: obscure_tech
+        tags:
+          old_obscure: 1
         has:
           plunge: 1
           kick: 2
@@ -592,7 +595,8 @@ regions:
             breaker: 1
             plunge: 1
         - and:
-          - ref: obscure_tech
+          - tags:
+              old_obscure: 1
           - has: breaker
           - or:
             - has:
@@ -606,7 +610,7 @@ regions:
         - has: breaker
         - or:
           - has:
-              bounce: 1
+              light: 1
               kick: 1
           - has:
               slide_jump: 1
@@ -622,7 +626,8 @@ regions:
         - has:
             breaker: 1
             plunge: 1
-        - ref: obscure_tech
+        - tags:
+            old_obscure: 1
           has: plunge
         - or:
           - has: kick
@@ -633,7 +638,8 @@ regions:
     - region: Bailey Upper
       rule:
         or:
-        - ref: obscure_tech
+        - tags:
+            old_obscure: 1
         - has:
             plunge: 1
             kick: 1
@@ -644,7 +650,8 @@ regions:
         - has: plunge
         - has:
             kick: 2
-        - ref: obscure_tech
+        - tags:
+            old_obscure: 1
   - name: Underbelly => Keep
     exits:
     - region: Keep => Underbelly
@@ -708,7 +715,7 @@ regions:
             old_obscure: 1
         - has:
             kick: 1
-            bounce: 1
+            light: 1
     - region: Bailey Lower
   - name: Castle => Theatre Pillar
     exits:
@@ -741,9 +748,9 @@ regions:
             slide_jump: 1
     - region: Dungeon Escape Upper
       rule:
-        option: darkrooms
+        ref: can_enter_darkrooms
         or:
-        - has: bounce
+        - has: light
         - has: kick
         - has:
             cling: 2
@@ -757,7 +764,7 @@ regions:
         - has:
             cling: 2
         - has: kick
-        - has: bounce
+        - has: light
         - has: slide_jump
         - tags:
             old_obscure: 1
@@ -775,7 +782,7 @@ origins:
   - spawn_point: library
     region: Library Main
   - spawn_point: underbelly_south
-    region: Underbelly South Exit
+    region: Underbelly => Bailey
   - spawn_point: underbelly_big_room
     region: Underbelly Main Upper
   - spawn_point: bailey_main
@@ -804,17 +811,17 @@ locations:
       or:
       - has:
           cling: 2
-          bounce: 1
+          light: 1
       - has:
           cling: 2
           kick_or_plunge: 3
       - has:
           kick: 2
-          bounce: 1
+          light: 1
       - has:
           slide_jump: 1
           kick: 1
-          bounce: 1
+          light: 1
   - name: Dilapidated Dungeon - Past Poles
     code: 5
     region: Dungeon Strong Eyes
@@ -828,8 +835,8 @@ locations:
       - has:
           slide_jump: 1
           kick: 2
-          tags:
-            old_obscure: 1
+        tags:
+          old_obscure: 1
   - name: Dilapidated Dungeon - Rafters
     code: 6
     region: Dungeon Strong Eyes
@@ -838,10 +845,10 @@ locations:
       - has:
           kick_or_plunge: 3
       - has:
-          bounce: 1
+          light: 1
           plunge: 1
-          tags:
-            old_obscure: 1
+        tags:
+          old_obscure: 1
   - name: Dilapidated Dungeon - Strong Eyes
     code: 7
     region: Dungeon Strong Eyes
@@ -912,18 +919,18 @@ locations:
     rule:
       or:
       - has:
-          bounce: 1
+          light: 1
           plunge: 1
       - has:
-          bounce: 1
+          light: 1
           kick: 2
       - has:
           kick: 4
       - has:
-          bounce: 1
+          light: 1
           kick: 1
-          tags:
-            old_obscure: 1
+        tags:
+          old_obscure: 1
   - name: Castle Sansa - Locked Door
     code: 13
     region: Castle Main
@@ -956,7 +963,7 @@ locations:
     region: Castle Main
     rule:
       or:
-      - has: bounce
+      - has: light
       - has:
           cling: 2
       - has:
@@ -1090,7 +1097,7 @@ locations:
       and:
       - has: strikebreak
       - or:
-        - has: bounce
+        - has: light
         - has: kick_or_plunge
         - has:
             cling: 2
@@ -1121,7 +1128,7 @@ locations:
       and:
       - ref: can_unlock_door
       - or:
-        - has: bounce
+        - has: light
         - has: kick
   - name: Twilight Theatre - Tucked Behind Boxes
     code: 34
@@ -1137,8 +1144,8 @@ locations:
       - has:
           plunge: 1
           kick: 3
-          tags:
-            old_obscure: 1  # use crouch backflip
+        tags:
+          old_obscure: 1  # use crouch backflip
       - has:
           kick: 4
 
@@ -1244,14 +1251,14 @@ locations:
       - has: plunge
       - has:
           kick: 2
-      - has: bounce
+      - has: light
   - name: The Underbelly - Strikebreak Wall
     code: 47
     region: Underbelly Main Upper
     rule:
       has:
         strikebreak: 1
-        bounce: 1
+        light: 1
         kick_or_plunge: 1
   - name: The Underbelly - Surrounded By Holes
     code: 48
@@ -1262,7 +1269,7 @@ locations:
           cutter: 1
           plunge: 1
       - or:
-        - has: bounce
+        - has: light
         - has:
             kick: 2
         - has: kick
@@ -1334,7 +1341,7 @@ locations:
         kick: 3
         cling: 6
         slide_jump: 1
-        bounce: 1
+        light: 1
     can_create:
       game_version: map_patch
       randomize_time_trials: true
@@ -1483,7 +1490,7 @@ locations:
           - has:
               cling: 2
           - has: kick
-          - has: bounce
+          - has: light
           - has: slide_jump
           - tags:
               old_obscure: 1
@@ -1548,8 +1555,8 @@ locations:
       - has:
           kick: 1
           plunge: 1
-          tags:
-            old_obscure: 1
+        tags:
+          old_obscure: 1
       - has:
           kick: 1
           slide_jump: 1
@@ -1656,13 +1663,13 @@ locations:
         - has:
             slide_jump: 1
             plunge: 1
-            tags:
-              old_obscure: 1
+          tags:
+            old_obscure: 1
         - has:
             slide_jump: 1
-            bounce: 1
-            tags:
-              old_obscure: 1
+            light: 1
+          tags:
+            old_obscure: 1
     can_create:
       randomize_chairs: true
 
@@ -1746,7 +1753,7 @@ locations:
       - has: plunge
       - has:
           cling: 2
-      - has: bounce
+      - has: light
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note in the Big Room
@@ -1771,7 +1778,7 @@ locations:
       randomize_notes: true
 
   - name: D S T RT ED M M O   Y
-    region: Tower Great Door
+    region: The Great Door
     rule:
       has:
         breaker: 1

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -166,21 +166,568 @@ origins:
   region: Theatre Main
 
 locations:
-- name: Dilapidated Dungeon - Dream Breaker
-  code: 1
-  region: Dungeon Mirror
-- name: Dilapidated Dungeon - Mirror Room Goatling
-  code: 66
-  region: Dungeon Mirror
-  can_create:
-    randomize_goats: true
-- name: D S T RT ED M M O   Y
-  region: Tower Great Door
-  rule:
-    has:
-      breaker: 1
-      major_key: 5
-  event_item: Something Worth Being Awake For
+  - name: Dilapidated Dungeon - Dream Breaker
+    code: 1
+    region: Dungeon Mirror
+    
+  - name: Dilapidated Dungeon - Slide
+    code: 2
+    region: Dungeon Slide
+    
+  - name: Dilapidated Dungeon - Alcove Near Mirror
+    code: 3
+    region: Dungeon => Castle
+    
+  - name: Dilapidated Dungeon - Dark Orbs
+    code: 4
+    region: Dungeon Escape Upper
+    
+  - name: Dilapidated Dungeon - Past Poles
+    code: 5
+    region: Dungeon Strong Eyes
+    
+  - name: Dilapidated Dungeon - Rafters
+    code: 6
+    region: Dungeon Strong Eyes
+    
+  - name: Dilapidated Dungeon - Strong Eyes
+    code: 7
+    region: Dungeon Strong Eyes
+    
+
+  - name: Castle Sansa - Indignation
+    code: 8
+    region: Castle Main
+    
+  - name: Castle Sansa - Alcove Near Dungeon
+    code: 9
+    region: Castle => Theatre Pillar
+    
+  - name: Castle Sansa - Balcony
+    code: 10
+    region: Castle Main
+    
+  - name: Castle Sansa - Corner Corridor
+    code: 11
+    region: Castle Main
+    
+  - name: Castle Sansa - Floater In Courtyard
+    code: 12
+    region: Castle Main
+    
+  - name: Castle Sansa - Locked Door
+    code: 13
+    region: Castle Main
+    can_create:
+      game_version: FULL_GOLD
+  - name: Castle Sansa - Platform In Main Halls
+    code: 14
+    region: Castle Main
+    
+  - name: Castle Sansa - Tall Room Near Wheel Crawlers
+    code: 15
+    region: Castle Main
+    
+  - name: Castle Sansa - Wheel Crawlers
+    code: 16
+    region: Castle Main
+    
+  - name: Castle Sansa - High Climb From Courtyard
+    code: 17
+    region: Castle High Climb
+    
+  - name: Castle Sansa - Alcove Near Scythe Corridor
+    code: 18
+    region: Castle By Scythe Corridor
+    
+  - name: Castle Sansa - Near Theatre Front
+    code: 19
+    region: Castle Moon Room
+    
+
+  - name: Sansa Keep - Strikebreak
+    code: 20
+    region: Keep Main
+    
+  - name: Sansa Keep - Alcove Near Locked Door
+    code: 21
+    region: Keep Locked Room
+    
+  - name: Sansa Keep - Levers Room
+    code: 22
+    region: Keep Main
+    
+  - name: Sansa Keep - Lonely Throne
+    code: 23
+    region: Keep Throne Room
+    
+  - name: Sansa Keep - Near Theatre
+    code: 24
+    region: Keep Main
+    
+  - name: Sansa Keep - Sunsetter
+    code: 25
+    region: Keep Sunsetter
+    
+
+  - name: Listless Library - Sun Greaves
+    code: 26
+    region: Library Greaves
+    can_create:
+      split_sun_greaves: false
+  - name: Listless Library - Upper Back
+    code: 27
+    region: Library Top
+    
+  - name: Listless Library - Locked Door Across
+    code: 28
+    region: Library Locked
+    
+  - name: Listless Library - Locked Door Left
+    code: 29
+    region: Library Locked
+    
+
+  - name: Twilight Theatre - Soul Cutter
+    code: 30
+    region: Theatre Main
+    
+  - name: Twilight Theatre - Back Of Auditorium
+    code: 31
+    region: Theatre Main
+    
+  - name: Twilight Theatre - Center Stage
+    code: 32
+    region: Theatre Main
+    
+  - name: Twilight Theatre - Locked Door
+    code: 33
+    region: Theatre Main
+    
+  - name: Twilight Theatre - Tucked Behind Boxes
+    code: 34
+    region: Theatre Main
+    
+  - name: Twilight Theatre - Corner Beam
+    code: 35
+    region: Theatre Pillar
+    
+
+  - name: Empty Bailey - Solar Wind
+    code: 36
+    region: Bailey Lower
+    
+  - name: Empty Bailey - Center Steeple
+    code: 37
+    region: Bailey Upper
+    
+  - name: Empty Bailey - Cheese Bell
+    code: 38
+    region: Bailey Upper
+    
+  - name: Empty Bailey - Guarded Hand
+    code: 39
+    region: Bailey Lower
+    
+  - name: Empty Bailey - Inside Building
+    code: 40
+    region: Bailey Lower
+    
+
+  - name: The Underbelly - Ascendant Light
+    code: 41
+    region: Underbelly Ascendant Light
+    
+  - name: The Underbelly - Alcove Near Light
+    code: 42
+    region: Underbelly Light Pillar
+    
+  - name: The Underbelly - Building Near Little Guy
+    code: 43
+    region: Underbelly => Bailey
+    
+  - name: The Underbelly - Locked Door
+    code: 44
+    region: Underbelly By Heliacal
+    
+  - name: The Underbelly - Main Room
+    code: 45
+    region: Underbelly Main Upper
+    
+  - name: The Underbelly - Rafters Near Keep
+    code: 46
+    region: Underbelly => Keep
+    
+  - name: The Underbelly - Strikebreak Wall
+    code: 47
+    region: Underbelly Main Upper
+    
+  - name: The Underbelly - Surrounded By Holes
+    code: 48
+    region: Underbelly Hole
+    
+
+  - name: Tower Remains - Cling Gem
+    code: 49
+    region: Tower Remains
+    can_create:
+      split_cling_gem: false
+  - name: Tower Remains - Atop The Tower
+    code: 50
+    region: The Great Door
+    
+
+  - name: Listless Library - Sun Greaves 1
+    code: 51
+    region: Library Greaves
+    can_create:
+      split_sun_greaves: true
+  - name: Listless Library - Sun Greaves 2
+    code: 52
+    region: Library Greaves
+    can_create:
+      split_sun_greaves: true
+  - name: Listless Library - Sun Greaves 3
+    code: 53
+    region: Library Greaves
+    can_create:
+      split_sun_greaves: true
+
+  - name: Dilapidated Dungeon - Time Trial
+    code: 54
+    region: Dungeon Mirror
+    can_create:
+      game_version: MAP_PATCH and options.randomize_time_trials
+  - name: Castle Sansa - Time Trial
+    code: 55
+    region: Castle Main
+    can_create:
+      game_version: MAP_PATCH and options.randomize_time_trials
+  - name: Sansa Keep - Time Trial
+    code: 56
+    region: Keep Throne Room
+    can_create:
+      game_version: MAP_PATCH and options.randomize_time_trials
+  - name: Listless Library - Time Trial
+    code: 57
+    region: Library Main
+    can_create:
+      game_version: MAP_PATCH and options.randomize_time_trials
+  - name: Twilight Theatre - Time Trial
+    code: 58
+    region: Theatre Pillar
+    can_create:
+      game_version: MAP_PATCH and options.randomize_time_trials
+  - name: Empty Bailey - Time Trial
+    code: 59
+    region: Bailey Upper
+    can_create:
+      game_version: MAP_PATCH and options.randomize_time_trials
+  - name: The Underbelly - Time Trial
+    code: 60
+    region: Underbelly Main Upper
+    can_create:
+      game_version: MAP_PATCH and options.randomize_time_trials
+  - name: Tower Remains - Time Trial
+    code: 61
+    region: The Great Door
+    can_create:
+      game_version: MAP_PATCH and options.randomize_time_trials
+
+  - name: Castle Sansa - Memento
+    code: 62
+    region: Castle Main
+    can_create:
+      game_version: MAP_PATCH
+
+  - name: Tower Remains - Cling Gem 1
+    code: 63
+    region: Tower Remains
+    can_create:
+      split_cling_gem: true
+  - name: Tower Remains - Cling Gem 2
+    code: 64
+    region: Tower Remains
+    can_create:
+      split_cling_gem: true
+  - name: Tower Remains - Cling Gem 3
+    code: 65
+    region: Tower Remains
+    can_create:
+      split_cling_gem: true
+
+  - name: Dilapidated Dungeon - Mirror Room Goatling
+    code: 66
+    region: Dungeon Mirror
+    can_create:
+      randomize_goats: true
+  - name: Dilapidated Dungeon - Rambling Goatling
+    code: 67
+    region: Dungeon Mirror
+    can_create:
+      randomize_goats: true
+  - name: Dilapidated Dungeon - Unwelcoming Goatling
+    code: 68
+    region: Dungeon Strong Eyes
+    can_create:
+      randomize_goats: true
+  - name: Dilapidated Dungeon - Repentant Goatling
+    code: 69
+    region: Dungeon Strong Eyes
+    can_create:
+      randomize_goats: true
+  - name: Dilapidated Dungeon - Defeatist Goatling
+    code: 70
+    region: Dungeon Strong Eyes
+    can_create:
+      randomize_goats: true
+  - name: Castle Sansa - Crystal Licker Goatling
+    code: 71
+    region: Castle Main
+    can_create:
+      randomize_goats: true
+  - name: Castle Sansa - Gazebo Goatling
+    code: 72
+    region: Castle Main
+    can_create:
+      randomize_goats: true
+  - name: Castle Sansa - Bubblephobic Goatling
+    code: 73
+    region: Castle Main
+    can_create:
+      randomize_goats: true
+  - name: Castle Sansa - Trapped Goatling
+    code: 74
+    region: Castle By Scythe Corridor
+    can_create:
+      randomize_goats: true
+  - name: Castle Sansa - Memento Goatling
+    code: 75
+    region: Castle Main
+    can_create:
+      randomize_goats and options.game_version: MAP_PATCH
+  - name: Castle Sansa - Goatling Near Library
+    code: 76
+    region: Castle Main
+    can_create:
+      randomize_goats and options.game_version: MAP_PATCH
+  - name: Sansa Keep - Furniture-less Goatling
+    code: 77
+    region: Keep Main
+    can_create:
+      randomize_goats: true
+  - name: Sansa Keep - Distorted Goatling
+    code: 78
+    region: Keep (Northeast) => Castle
+    can_create:
+      randomize_goats: true
+  - name: Twilight Theatre - 20 Bean Casserole Goatling
+    code: 79
+    region: Castle => Theatre (Front)
+    can_create:
+      randomize_goats: true
+  - name: Twilight Theatre - Theatre Goer Goatling 1
+    code: 80
+    region: Castle => Theatre (Front)
+    can_create:
+      randomize_goats: true
+  - name: Twilight Theatre - Theatre Goer Goatling 2
+    code: 81
+    region: Castle => Theatre (Front)
+    can_create:
+      randomize_goats: true
+  - name: Twilight Theatre - Theatre Manager Goatling
+    code: 82
+    region: Castle => Theatre (Front)
+    can_create:
+      randomize_goats: true
+  - name: Twilight Theatre - Murderous Goatling
+    code: 83
+    region: Theatre Main
+    can_create:
+      randomize_goats: true
+  - name: Empty Bailey - Alley Goatling
+    code: 84
+    region: Bailey Lower
+    can_create:
+      randomize_goats: true
+
+  - name: Castle Sansa - Stool Near Crystal 1
+    code: 85
+    region: Castle Main
+    can_create:
+      randomize_chairs: true
+  - name: Castle Sansa - Stool Near Crystal 2
+    code: 86
+    region: Castle Main
+    can_create:
+      randomize_chairs: true
+  - name: Castle Sansa - Stool Near Crystal 3
+    code: 87
+    region: Castle Main
+    can_create:
+      randomize_chairs: true
+  - name: Castle Sansa - Gazebo Stool
+    code: 88
+    region: Castle Main
+    can_create:
+      randomize_chairs: true
+  - name: Sansa Keep - Distorted Stool
+    code: 89
+    region: Keep (Northeast) => Castle
+    can_create:
+      randomize_chairs: true
+  - name: Sansa Keep - Path to Throne Stool
+    code: 90
+    region: Keep Throne Room
+    can_create:
+      randomize_chairs: true
+  - name: Sansa Keep - The Throne
+    code: 91
+    region: Keep Throne Room
+    can_create:
+      randomize_chairs: true
+  - name: Listless Library - Hay Bale Near Entrance
+    code: 92
+    region: Library Main
+    can_create:
+      randomize_chairs: true
+  - name: Listless Library - Hay Bale Near Eggs
+    code: 93
+    region: Library Top
+    can_create:
+      randomize_chairs: true
+  - name: Listless Library - Hay Bale in the Back
+    code: 94
+    region: Library Back
+    can_create:
+      randomize_chairs: true
+  - name: Twilight Theatre - Stool Near Bookcase
+    code: 95
+    region: Theatre Outside Scythe Corridor
+    can_create:
+      randomize_chairs: true
+  - name: Twilight Theatre - Stool Around a Table 1
+    code: 96
+    region: Theatre Outside Scythe Corridor
+    can_create:
+      randomize_chairs: true
+  - name: Twilight Theatre - Stool Around a Table 2
+    code: 97
+    region: Theatre Outside Scythe Corridor
+    can_create:
+      randomize_chairs: true
+  - name: Twilight Theatre - Stool Around a Table 3
+    code: 98
+    region: Theatre Outside Scythe Corridor
+    can_create:
+      randomize_chairs: true
+  - name: Twilight Theatre - Stage Left Stool
+    code: 99
+    region: Theatre Main
+    can_create:
+      randomize_chairs: true
+  - name: Twilight Theatre - Stage Right Stool
+    code: 100
+    region: Theatre Main
+    can_create:
+      randomize_chairs: true
+
+  - name: Listless Library - A Book About a Princess
+    code: 101
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About Cooking
+    code: 102
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book Full of Plays
+    code: 103
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About Reading
+    code: 104
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About Aquatic Life
+    code: 105
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About a Jester
+    code: 106
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About Loss
+    code: 107
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book on Musical Theory
+    code: 108
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About a Girl
+    code: 109
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About a Thimble
+    code: 110
+    region: Library Main
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About a Monster
+    code: 111
+    region: Library Greaves
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About Revenge
+    code: 112
+    region: Library Greaves
+    can_create:
+      randomize_books: true
+  - name: Listless Library - A Book About a Restaurant
+    code: 113
+    region: Library Top
+    can_create:
+      randomize_books: true
+
+  - name: Listless Library - Note Near Eggs
+    code: 114
+    region: Library Top
+    can_create:
+      randomize_notes: true
+  - name: The Underbelly - Note on a Ledge
+    code: 115
+    region: Underbelly => Bailey
+    can_create:
+      randomize_notes: true
+  - name: The Underbelly - Note in the Big Room
+    code: 116
+    region: Underbelly Main Lower
+    can_create:
+      randomize_notes: true
+  - name: The Underbelly - Note Behind a Locked Door
+    code: 117
+    region: Underbelly By Heliacal
+    can_create:
+      randomize_notes: true
+
+  - name: D S T RT ED M M O   Y
+    region: Tower Great Door
+    rule:
+      has:
+        breaker: 1
+        major_key: 5
+    event_item: Something Worth Being Awake For
+
 
 completion_rule:
   has: Something Worth Being Awake For

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -118,13 +118,19 @@ regions:
         has: slide
     - region: Dungeon Escape Lower
       rule:
-        or:
-        - and:
-          - ref: can_attack
-          - ref: can_enter_dark_rooms
-        - has: breaker
-          tags:
-            dungeon_escape: 1
+        ref:
+          - dungeon_escape
+          - can_attack
+        options: darkrooms
+      # keeping this version for reference, but keeping the assumptions about macros consistent
+      # rule:
+      #   or:
+      #   - and:
+      #     - ref: can_attack
+      #     - ref: can_enter_dark_rooms
+      #   - has: breaker
+      #     tags:
+      #       dungeon_escape: 1
   - name: Dungeon Strong Eyes
     exits:
     - region: Dungeon Slide
@@ -162,99 +168,272 @@ regions:
   - name: Dungeon Escape Lower
     exits:
     - region: Dungeon Slide
-      rule: null
+      rule:
+        ref: can_attack
     - region: Dungeon Escape Upper
-      rule: null
+      rule:
+        or:
+        - has: bounce
+        - has:
+            kick: 1
+            plunge: 1
+        - has:
+            kick: 3
     - region: Underbelly => Dungeon
   - name: Dungeon Escape Upper
     exits:
     - region: Dungeon Escape Lower
-      rule: null
     - region: Theatre Outside Scythe Corridor
-      rule: null
+      rule:
+        or:
+        - has: bounce
+        - has: kick
+        - has:
+            cling: 2
+        - tags: obscure_tech
+          has: plunge
   - name: Castle Main
     exits:
     - region: Dungeon => Castle
     - region: Keep Main
     - region: Bailey Lower
     - region: Library Main
-      rule: null
+      rule:
+        ref: can_attack
     - region: Castle => Theatre Pillar
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+            kick_or_plunge: 1
+        - has:
+            kick_or_plunge: 2
     - region: Castle Spiral Climb
-      rule: null
+      rule:
+        or:
+        - has:
+            kick: 2
+        - has:
+            cling: 2
+            plunge: 1
     - region: Keep (Northeast) => Castle
-      rule: null
+      rule:  # TODO: not sure about this logic, idk where doing it with no items should go
+        or:
+        - ref: can_attack
+        - tag: obscure_tech
   - name: Castle Spiral Climb
     exits:
     - region: Castle Main
     - region: Castle High Climb
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has:
+            kick: 3
+            plunge: 1
+        - ref: can_attack
+          has: kick
     - region: Castle By Scythe Corridor
-      rule: null
+      rule:
+        has:
+          cling: 2
   - name: Castle High Climb
 
   - name: Castle By Scythe Corridor
     exits:
     - region: Castle Spiral Climb
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has:
+            kick: 4
+            plunge: 1
     - region: Castle High Climb
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has:
+            kick: 4
+        - has:
+            kick: 2
+            plunge: 1
+        - has:
+            kick: 1
+            plunge: 1
+            slide_jump: 1
     - region: Castle => Theatre (Front)
-      rule: null
+      rule:
+        has:
+          cling: 4
+          kick_or_plunge: 2
   - name: Castle => Theatre (Front)
     exits:
     - region: Castle By Scythe Corridor
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has:
+            slide_jump: 1
+            kick: 1
+        - has:
+            kick: 4
     - region: Castle Moon Room
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has:
+            slide_jump: 1
+            kick_or_plunge: 2
     - region: Theatre Main
-      rule: null
+      rule:
+        or:
+        - has:
+            plunge: 1
+            kick: 1
+        - has:
+            kick: 2
   - name: Castle Moon Room
 
 
   - name: Library Main
     exits:
     - region: Library Locked
-      rule: null
+      rule:
+        ref: can_unlock_door
     - region: Library Greaves
-      rule: null
+      rule:
+        has: slide
     - region: Library Top
-      rule: null
+      rule:
+        or:
+        - has:
+            kick_or_plunge: 4
+        - ref: obscure_tech
+          has:
+            kick: 1
+            plunge: 1
     - region: Castle Main
-      rule: null
+      rule:
+        ref: can_attack
   - name: Library Locked
 
   - name: Library Greaves
     exits:
     - region: Library Back
-      rule: null
+      rule:
+        ref: can_attack
+        or:
+        - has:
+            cling: 2
+        - has:
+            kick: 2
   - name: Library Top
     exits:
     - region: Library Back
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+            kick_or_plunge: 1
+        - has:
+            kick: 3
+            plunge: 1
+        - has:
+            kick: 3
+            bounce: 1
   - name: Library Back
     exits:
     - region: Library Greaves
-      rule: null
+      rule:
+        ref: can_attack
+        or:
+        - has:
+            cling: 2
+        - has:
+            kick: 1
     - region: Library Top
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 4
+        - has:
+            kick: 2
   - name: Keep Main
     exits:
     - region: Keep Locked Room
-      rule: null
+      rule:
+        or:
+        - ref: can_unlock_door
+        - has:
+            kicks: 3
+        - has:
+            plunge: 1
+            kick: 1
+        - has:
+            cling: 2
+            plunge: 1
+        - has:
+            cling: 2
+            kick: 1
+      # Note for trackers: This is accessible with nothing but not in logic.
+      # Cutting the platform or hitting the lever make this harder and are irreversible.
+      # On Hard and above, the player is expected to not do either.
     - region: Keep Sunsetter
-      rule: null
+      rule:
+        has:
+          cling: 2
+          # See "Keep Main -> Keep Locked Room".
+          # All other methods would go through Keep Locked Room instead.
     - region: Keep Throne Room
-      rule: null
+      rule:
+        or:
+        - and:
+          - has:
+              breaker: 1
+              cling: 6
+          - or:
+              - has:
+                  plunge: 1
+                  kick: 1
+              - has:
+                  plunge: 1
+                  bounce: 1
+              - has:
+                  kick: 1
+                  bounce: 1
+        - has:
+            bounce: 1
+            kick_or_plunge: 4
     - region: Keep => Underbelly
-      rule: null
+      rule:
+        or:
+        - has: kick_or_plunge
+        - has:
+            cling: 2
     - region: Theatre Outside Scythe Corridor
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has: kick
+        - has: bounce
+        - has: slide_jump
+        - ref: obscure_tech
+          has: plunge  # TODO: this doesn't really matter right now but is a little questionable for normal
     - region: Keep (Northeast) => Castle
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has:
+            kick: 2
+        - has: plunge
     - region: Castle Main
-      rule: null
   - name: Keep Locked Room
     exits:
     - region: Keep Sunsetter
@@ -273,15 +452,22 @@ regions:
   - name: Bailey Lower
     exits:
     - region: Bailey Upper
-      rule: null
+      rule:
+        or:
+        - has: slide
+          ref: can_attack
+        - has:
+            kick: 2
+        - has: kick
+          tag: obscure_tech
     - region: Castle Main
     - region: Theatre Pillar => Bailey
   - name: Bailey Upper
     exits:
     - region: Bailey Lower
-      rule: null
     - region: Underbelly => Bailey
-      rule: null
+      rule:
+        has: plunge
     - region: Tower Remains
       rule:
         and:
@@ -301,95 +487,264 @@ regions:
   - name: Tower Remains
     exits:
     - region: The Great Door
-      rule: null
+      rule:
+        ref: can_attack
+        has:
+          cling: 2
+          kick_or_plunge: 1
   - name: Underbelly => Dungeon
     exits:
     - region: Dungeon Escape Lower
-      rule: null
+      rule:
+        options: darkrooms
     - region: Underbelly Light Pillar
     - region: Underbelly Ascendant Light
-      rule: null
+      rule:
+        or:
+        - has: bounce
+        - has:
+            cling: 2
+            kick: 1
+        - has:
+            kick: 2
+        - has:
+            kick: 1
+            slide_jump: 1
+        - ref:
+          - obscure_tech
+          - can_attack
   - name: Underbelly Light Pillar
     exits:
     - region: Underbelly Main Upper
     - region: Underbelly => Dungeon
-      rule: null
+      rule:
+        or:
+        - has: bounce
+        - has:
+            kick_or_plunge: 4
     - region: Underbelly Ascendant Light
-      rule: null
+      # this route is more difficult with ascendant light because of the long room with the switches, but
+      # since it's possible to use AL to go up the pillar and get to the item that way (i.e. passing through
+      # Underbelly => Dungeon), the logic for this entrance is written assuming the player doesn't have AL
+      rule:
+        and:
+        - has: breaker
+        - or:
+          - has: plunge
+          - has:
+              kick: 3
+            tag: obscure_tech
   - name: Underbelly Ascendant Light
     exits:
     - region: Underbelly => Dungeon
-      rule: null
+      rule:
+        or:
+        - has: bounce
+        - has:
+            cling: 2
+        - has:
+            kick: 2
+        - has:
+            kick: 1
+            slide_jump: 1
   - name: Underbelly Main Lower
     exits:
     - region: Underbelly => Bailey
     - region: Underbelly Hole
-      rule: null
+      rule:
+        and:
+        - has: plunge
+        - or:
+          - has: kick
+          - has: slide_jump
+          - ref: can_attack
     - region: Underbelly By Heliacal
-      rule: null
+      rule:
+        has:
+          slide: 1
+          plunge: 1
     - region: Underbelly Main Upper
-      rule: null
+      rule:
+        ref: obscure_tech
+        has:
+          plunge: 1
+          kick: 2
   - name: Underbelly Main Upper
     exits:
     - region: Underbelly Main Lower
     - region: Underbelly Light Pillar
-      rule: null
+      rule:
+        or:
+        - has:
+            breaker: 1
+            plunge: 1
+        - and:
+          - ref: obscure_tech
+          - has: breaker
+          - or:
+            - has:
+                kick: 2
+            - has:
+                cling: 2
+                kick: 1
     - region: Underbelly By Heliacal
-      rule: null
+      rule:
+        and:
+        - has: breaker
+        - or:
+          - has:
+              bounce: 1
+              kick: 1
+          - has:
+              slide_jump: 1
+              kick: 3
+          - has:
+              cling: 2
+              kick: 2
   - name: Underbelly By Heliacal
     exits:
     - region: Underbelly Main Upper
-      rule: null
+      rule:
+        or:
+        - has:
+            breaker: 1
+            plunge: 1
+        - ref: obscure_tech
+          has: plunge
+        - or:
+          - has: kick
+          - has:
+              cling: 2
   - name: Underbelly => Bailey
     exits:
     - region: Bailey Upper
-      rule: null
+      rule:
+        or:
+        - ref: obscure_tech
+        - has:
+            plunge: 1
+            kick: 1
     - region: Bailey Lower
     - region: Underbelly Main Lower
-      rule: null
+      rule:
+        or:
+        - has: plunge
+        - has:
+            kick: 2
+        - ref: obscure_tech
   - name: Underbelly => Keep
     exits:
     - region: Keep => Underbelly
     - region: Underbelly Hole
-      rule: null
+      rule:
+        has: plunge
   - name: Underbelly Hole
     exits:
     - region: Underbelly Main Lower
-      rule: null
+      rule:
+        and:
+        - has: plunge
+        - or:
+          - ref: can_attack
+          - has:
+              slide_jump: 1
+              cling: 2
+          - has:
+              slide_jump: 1
+              kick: 1
     - region: Underbelly => Keep
-      rule: null
+      rule:
+        has:
+          plunge: 1
+          slide: 1
   - name: Theatre Main
     exits:
     - region: Theatre Outside Scythe Corridor
-      rule: null
+      rule:
+        has:
+          cling: 6
     - region: Theatre Pillar
-      rule: null
+      rule:
+        or:
+        - has:
+            kick: 2
+        - has:
+            kick: 1
+            plunge: 1
+          tag: obscure_tech
+        - has:
+            kick: 1
+            slide_jump: 1
+        - has:
+            cling: 2
     - region: Castle => Theatre (Front)
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has: kick
+        - has: slide_jump
   - name: Theatre Pillar => Bailey
     exits:
     - region: Theatre Pillar
-      rule: null
+      rule:
+        or:
+        - has: plunge
+          tags: obscure_tech
+        - has:
+            kick: 1
+            bounce: 1
     - region: Bailey Lower
   - name: Castle => Theatre Pillar
     exits:
     - region: Theatre Pillar
-      rule: null
+      rule:
+        has: plunge
     - region: Castle Main
   - name: Theatre Pillar
     exits:
     - region: Theatre Main
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has:
+            plunge: 1
+            kick: 3
     - region: Theatre Pillar => Bailey
     - region: Castle => Theatre Pillar
   - name: Theatre Outside Scythe Corridor
     exits:
     - region: Theatre Main
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 6
+            kick_or_plunge: 3
+        - has:
+            cling: 6
+            slide_jump: 1
     - region: Dungeon Escape Upper
-      rule: null
+      rule:
+        option: darkrooms
+        or:
+        - has: bounce
+        - has: kick
+        - has:
+            cling: 2
+        - has: slide_jump
+        - tags: obscure_tech
+          has: plunge
     - region: Keep Main
-      rule: null
+      rule:
+        or:
+        - has:
+            cling: 2
+        - has: kick
+        - has: bounce
+        - has: slide_jump
+        - tags: obscure_tech
+          has: plunge
   - name: The Great Door
 
 
@@ -495,7 +850,6 @@ locations:
   - name: Castle Sansa - Indignation
     code: 8
     region: Castle Main
-    rule: null
   - name: Castle Sansa - Alcove Near Dungeon
     code: 9
     region: Castle => Theatre Pillar

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -120,10 +120,16 @@ regions:
         has: slide
     - region: Dungeon Escape Lower
       rule:
-        and:
+        or:
+        - and:
           #  - ref: dungeon_escape  # TODO: add this later
           - ref: can_attack
           - ref: can_enter_dark_rooms
+        - options:
+            difficulty: expert
+          ref: can_gold_ultra
+          has: kick
+
       # keeping this version for reference, but keeping the assumptions about macros consistent
       # rule:
       #   or:
@@ -244,6 +250,9 @@ regions:
         - tags:
             old_obscure: 1
           has: plunge
+        - options:
+            difficulty: expert
+          has: slide
   - name: Castle Main
     exits:
     - region: Dungeon => Castle
@@ -267,6 +276,9 @@ regions:
         - options:
             difficulty: hard
           - has: kick
+        - options:
+            difficulty: expert
+          has: slide
     - region: Castle Spiral Climb
       rule:
         or:
@@ -288,6 +300,14 @@ regions:
           has:
             slide_jump: 1
             plunge: 1
+        - options:
+            difficulty: expert
+          ref: can_gold_ultra
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick_or_plunge: 1
     - region: Keep (Northeast) => Castle
       rule:  # TODO: not sure about this logic, idk where doing it with no items should go
         or:
@@ -317,10 +337,27 @@ regions:
             old_obscure: 1
           reg: can_attack
           has: slide_jump
+        - options:
+            difficulty: expert
+          ref: can_gold_slide_ultra
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick_or_plunge: 1
+        - options:
+            difficulty: expert
+          has:
+            kick: 2
     - region: Castle By Scythe Corridor
       rule:
-        has:
-          cling: 2
+        or:
+        - has:
+            cling: 2
+        - options:
+            difficulty: expert
+          has:
+            kick_or_plunge: 4
   - name: Castle High Climb
 
   - name: Castle By Scythe Corridor
@@ -361,15 +398,33 @@ regions:
           has:
             kick: 1
             plunge: 1
+        - options:
+            difficulty: expert
+          has: slide
+        - options:
+            difficulty: expert
+          has:
+            kick_or_plunge: 2
     - region: Castle => Theatre (Front)
       rule:
-        has:
-          cling: 4
-          kick_or_plunge: 2
+        or:
+        - has:
+            cling: 4
+            kick_or_plunge: 2
         - options:
             difficulty: hard
           has:
             cling: 6
+        - options:
+            difficulty: expert
+          ref: can_gold_ultra
+          has:
+            kick: 2
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick_or_plunge: 3
   - name: Castle => Theatre (Front)
     exits:
     - region: Castle By Scythe Corridor
@@ -382,6 +437,18 @@ regions:
             kick: 1
         - has:
             kick: 4
+        - options:
+            difficulty: expert
+          ref: can_gold_slide_ultra
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick: 1
+        - options:
+            difficulty: expert
+          has:
+            kick: 3
     - region: Castle Moon Room
       rule:
         or:
@@ -394,6 +461,9 @@ regions:
             difficulty: hard
           has:
             kick: 4
+        - options:
+            difficulty: expert
+          has: slide
     - region: Theatre Main
       rule:
         or:
@@ -406,6 +476,14 @@ regions:
             difficulty: hard
           has:
             kick: 4  # TODO double check for hard logic
+        - options:
+            difficulty: expert
+          ref: can_gold_slide_ultra
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick_or_plunge: 1
   - name: Castle Moon Room
 
 
@@ -437,6 +515,12 @@ regions:
             old_obscure: 1
           has:
             kick_or_plunge: 2
+        - options:
+            difficulty: expert
+          has: plunge
+        - options:
+            difficulty: expert
+          has: slide
     - region: Castle Main
       rule:
         ref: can_attack
@@ -456,6 +540,9 @@ regions:
             difficulty: hard
           ref: can_attack
           has: kick
+        - options:
+            difficulty: expert
+          has: slide
   - name: Library Top
     exits:
     - region: Library Back
@@ -484,6 +571,10 @@ regions:
             kick: 2
             plunge: 1
             light: 1
+        - options:
+            difficulty: expert
+          has:
+            kick: 2
   - name: Library Back
     exits:
     - region: Library Greaves
@@ -508,6 +599,9 @@ regions:
             difficulty: hard
           has:
             cling: 2
+        - options:
+            difficulty: expert
+          has: slide
   - name: Keep Main
     exits:
     - region: Keep Locked Room
@@ -582,12 +676,44 @@ regions:
           has:
             light: 1
             kick: 3
+        - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            cling: 4
+        - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            cling: 2
+            kick: 1
+        - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            cling: 2
+            slide: 1
+        - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            light: 1
+            kick_or_plunge: 3
+         - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            slide: 1
+            kick: 3
     - region: Keep => Underbelly
       rule:
         or:
         - has: kick_or_plunge
         - has:
             cling: 2
+        - options:
+            difficulty: expert
+          has: slide
     - region: Theatre Outside Scythe Corridor
       rule:
         or:
@@ -599,6 +725,9 @@ regions:
         - tags:
             old_obscure: 1
           has: plunge  # TODO: this doesn't really matter right now but is a little questionable for normal
+        - options:
+            difficulty: expert
+          has: slide
     - region: Keep (Northeast) => Castle
       rule:
         or:
@@ -610,6 +739,9 @@ regions:
         - options:
             difficulty: hard
           has: kick
+        - options:
+            difficulty: expert
+          has: slide
     - region: Castle Main
   - name: Keep Locked Room
     exits:
@@ -645,6 +777,9 @@ regions:
             difficulty: hard
           has:
             cling: 2
+        - options:
+            difficulty: expert
+          has: slide
     - region: Castle Main
     - region: Theatre Pillar => Bailey
   - name: Bailey Upper
@@ -711,6 +846,22 @@ regions:
           ref: can_attack
           has:
             cling: 2
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            cling: 2
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick: 2
+        - options:
+            difficulty: expert
+          ref: can_gold_ultra
+          has:
+            kick: 1
+            plunge: 1
   - name: Underbelly => Dungeon
     exits:
     - region: Dungeon Escape Lower
@@ -737,6 +888,11 @@ regions:
             difficulty: hard
           has:
             cling: 2
+        - options:
+            difficulty: expert
+          has:
+            kick: 1
+            slide: 1
   - name: Underbelly Light Pillar
     exits:
     - region: Underbelly Main Upper
@@ -746,6 +902,22 @@ regions:
         - has: light
         - has:
             kick_or_plunge: 4
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick: 3
+        - options:
+            difficulty: expert
+          ref: can_gold_ultra
+          has:
+            kick: 1
+            plunge: 1
+        - options:
+            difficulty: expert
+          has:
+            plunge: 1
+            kick: 2
     - region: Underbelly Ascendant Light
       # this route is more difficult with ascendant light because of the long room with the switches, but
       # since it's possible to use AL to go up the pillar and get to the item that way (i.e. passing through
@@ -774,6 +946,22 @@ regions:
           has:
             plunge: 1
             cling: 2
+        - options:
+            difficulty: expert
+          has:
+            plunge: 1
+            kick: 1
+        - options:
+            difficulty: expert
+          ref: can_attack
+          has:
+            slide: 1
+        - options:
+            difficulty: expert
+          ref: can_gold_ultra
+          has:
+            kick: 3
+            cling: 4
   - name: Underbelly Ascendant Light
     exits:
     - region: Underbelly => Dungeon
@@ -787,6 +975,16 @@ regions:
         - has:
             kick: 1
             slide_jump: 1
+        - options:
+            difficulty: expert
+          has:
+            kick: 1
+            slide: 1
+        - options:
+            difficulty: expert
+          has:
+            kick: 1
+            plunge: 1
   - name: Underbelly Main Lower
     exits:
     - region: Underbelly => Bailey
@@ -806,35 +1004,62 @@ regions:
             cling: 4
     - region: Underbelly By Heliacal
       rule:
-        has:
-          slide: 1
-          plunge: 1
+        or:
+        - has:
+            slide: 1
+            plunge: 1
         - options:
             difficulty: hard
           has:
             slide: 1
             kick: 2
+        - options:
+            difficulty: expert
+          has: slide
     - region: Underbelly Main Upper
       rule:
-        tags:
-          old_obscure: 1
-        has:
-          plunge: 1
-          kick: 2
-        - options:
-            difficulty: hard
-          tags:
+        or:
+        - tags:
             old_obscure: 1
           or:
           - has:
               plunge: 1
+              kick: 2
+          - options:
+              difficulty: hard
+            has:
+              plunge: 1
               kick: 1
-          - has:
+          - options:
+              difficulty: hard
+            has:
               plunge: 1
               cling: 4
-          - has:
+          - options:
+              difficulty: hard
+            has:
               kick: 2
               cling: 2
+        - options:
+            difficulty: expert
+          has:
+            kick: 2
+        - options:
+            difficulty: expert
+          has:
+            kick: 1
+            cling: 2
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            cling: 4
+        - options:
+            difficulty: expert
+          ref: can_gold_slide_ultra
+          has:
+            kick: 1
+            breaker: 1
   - name: Underbelly Main Upper
     exits:
     - region: Underbelly Main Lower
@@ -867,6 +1092,31 @@ regions:
             slide_jump: 1
             kick: 1
             plunge: 1
+        - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            slide: 1
+        - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            kick: 1
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick_or_plunge: 3
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            cling: 6
+        - options:
+            difficulty: expert
+          ref: can_gold_ultra
+          has:
+            kick_or_plunge: 2
     - region: Underbelly By Heliacal
       rule:
         and:
@@ -881,6 +1131,33 @@ regions:
           - has:
               cling: 2
               kick: 2
+          - options:
+              difficulty: hard
+            has: light
+          - options:
+              difficulty: hard
+            has:
+              cling: 2
+              kick_or_plunge: 1
+          - options:
+              difficulty: hard
+            has:
+              kick_or_plunge: 4
+          - options:
+              difficulty: hard
+            tags:
+              old_obscure: 1
+            has:
+              cling:4
+          - options:
+              difficulty: expert
+            has:
+              slide: 1
+              kick: 2
+          - options:
+              difficulty: expert
+            has:
+              kick: 3
   - name: Underbelly By Heliacal
     exits:
     - region: Underbelly Main Upper
@@ -891,26 +1168,42 @@ regions:
             plunge: 1
         - tags:
             old_obscure: 1
-          has: plunge
-        - or:
-          - has: kick
-          - has:
-              cling: 2
+          has:
+            plunge: 1
+            kick: 1
+        - tags:
+            old_obscure: 1
+          has:
+            plunge: 1
+            cling: 2
         - options:
-            difficulty: hard
-          and:
-          - has: breaker
-          - or:
-            - has: light
-            - has:
-                cling: 2
-                kick_or_plunge: 1
-            - has:
-                kick_or_plunge: 4
-            - tags:
-                old_obscure: 1
-              has:
-                cling: 4
+            difficulty: expert
+          has: plunge
+        - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            slide: 1
+        - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            cling: 2
+        - options:
+            difficulty: expert
+          has:
+            breaker: 1
+            kick: 1
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            cling: 2
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick: 2
   - name: Underbelly => Bailey
     exits:
     - region: Bailey Upper
@@ -1014,6 +1307,9 @@ regions:
             cling: 2
         - has: kick
         - has: slide_jump
+        - options:
+            difficulty: expert
+          has: slide
   - name: Theatre Pillar => Bailey
     exits:
     - region: Theatre Pillar
@@ -1033,6 +1329,13 @@ regions:
             difficulty: hard
           has:
             slide_jump: 1
+        - options:
+            difficulty: expert
+          has: slide
+        - options:
+            difficulty: expert
+          has:
+            cling: 2
     - region: Bailey Lower
   - name: Castle => Theatre Pillar
     exits:
@@ -1041,8 +1344,18 @@ regions:
       - rule:
           has: plunge
       - options:
-         difficulty: hard
+          difficulty: hard
         has: slide_jump
+      - options:
+          difficulty: expert
+        has: kick
+      - options:
+          difficulty: expert
+        has:
+          cling: 2
+      - options:
+          difficulty: expert
+        has: slide
     - region: Castle Main
   - name: Theatre Pillar
     exits:
@@ -1058,6 +1371,11 @@ regions:
             difficulty: hard
           has:
             slide_jump: 1
+            kick_or_plunge: 3
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
             kick_or_plunge: 3
     - region: Theatre Pillar => Bailey
     - region: Castle => Theatre Pillar
@@ -1088,6 +1406,10 @@ regions:
         - tags:
             old_obscure: 1
           has: plunge
+        - options:
+            difficulty: expert
+          ref: can_enter_darkrooms
+          has: slide
     - region: Keep Main
       rule:
         or:
@@ -1099,6 +1421,9 @@ regions:
         - tags:
             old_obscure: 1
           has: plunge
+        - options:
+            difficulty: expert
+          has: slide
   - name: The Great Door
 
 

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -32,138 +32,383 @@ item_mapping:
     name: major_key
     max: 1
   Progressive Slide:
-  - slide
-  - slide_jump
+    - slide
+    - slide_jump
   Air Kick: kick
   Progressive Dream Breaker:
-  - breaker
-  - strikebreak
-  - cutter
+    - breaker
+    - strikebreak
+    - cutter
   Cling Shard:
     name: cling
     count: 2
 
 tags:
-- name: plunge_attack
-  advanced:
-    Sunsetter plunge does damage, even if you don't have Dream Breaker.
-    In addition to breaking floors,
-    this can be used to break weak walls and hit switches.
-- name: not_afraid_of_the_dark
-  expert:
-    With this tag, the Dungeon dark rooms are in logic as soon as you can enter them,
-    even if you don't have a way to light your path.
-- name: slide_ultras
-  description: This tech involves cancelling a slide and converting its high speed into a high jump.
-  hard: At this level, you may be required to use slide ultras purely to gain height.
-  expert: At this level, you may be required to use slide ultras for distance, which can require higher speed.
-  lunatic: At this level, slide ultra setups may be very precise, involving very small runway or sharp angle changes.
+  - name: plunge_attack
+    advanced:
+      Sunsetter plunge does damage, even if you don't have Dream Breaker.
+      In addition to breaking floors,
+      this can be used to break weak walls and hit switches.
+  - name: not_afraid_of_the_dark
+    expert:
+      With this tag, the Dungeon dark rooms are in logic as soon as you can enter them,
+      even if you don't have a way to light your path.
+  - name: slide_ultras
+    description: This tech involves cancelling a slide and converting its high speed into a high jump.
+    hard: At this level, you may be required to use slide ultras purely to gain height.
+    expert: At this level, you may be required to use slide ultras for distance, which can require higher speed.
+    lunatic: At this level, slide ultra setups may be very precise, involving very small runway or sharp angle changes.
 
 tag_groups:
-- name: basic_tech
-  description: This group includes basic and well known tech and introduces meaningful additions at every logic level.
-  children:
-  - basic_slide_tech
-  - basic_kick_tech
-  # etc
-- name: obscure_tech
-  description: This group compiles less known tech into a single group.
-  children:
-  - plunge_attack
-  - not_afraid_of_the_dark
-  # etc
+  - name: basic_tech
+    description: This group includes basic and well known tech and introduces meaningful additions at every logic level.
+    children:
+    - basic_slide_tech
+    - basic_kick_tech
+    # etc
+  - name: obscure_tech
+    description: This group compiles less known tech into a single group.
+    children:
+    - plunge_attack
+    - not_afraid_of_the_dark
+    # etc
 
 ref_rules:
-- name: can_attack
-  rule:
-    or:
-    - has: breaker
-    - has: plunge
-      tags:
-        plunge_attack: 1
-- name: can_unlock_door
-  rule:
-    and:
-    - ref: can_attack
-    - or:
-      - has:
-          small_key: 7
-      - has:
-          small_key: 6
-        tags:
-          smart_keys: 1
-- name: can_enter_dark_rooms
-  rule:
-    or:
-    - has: light
-    - has: breaker
-      tags:
-        light_breaker: 1
-    - tags:
-        not_afraid_of_the_dark: 3
-
-regions:
-- name: Dungeon Mirror
-  exits:
-  - region: Dungeon Slide
-    rule:
-      ref: can_attack
-- name: Dungeon Slide
-  exits:
-  - region: Dungeon Mirror
-    rule:
-      ref: can_attack
-  - region: Dungeon Strong Eyes
-    rule:
-      has: slide
-  - region: Dungeon Escape Lower
+  - name: can_attack
     rule:
       or:
-      - and:
-        - ref: can_attack
-        - ref: can_enter_dark_rooms
+      - has: breaker
+      - has: plunge
         tags:
-          obscure_paths: 1
+          plunge_attack: 1
+  - name: can_unlock_door
+    rule:
+      and:
+      - ref: can_attack
+      - or:
+        - has:
+            small_key: 7
+        - has:
+            small_key: 6
+          tags:
+            smart_keys: 1
+  - name: can_enter_dark_rooms
+    rule:
+      or:
+      - has: light
       - has: breaker
         tags:
-          dungeon_escape: 1
-- name: Dungeon Strong Eyes
-  exits:
-  - region: Dungeon Slide
-    rule:
-      has: slide
-  - region: Dungeon Top Exit
-- name: Dungeon Top Exit
-  exits:
-  - region: Dungeon Mirror
-  - region: Dungeon Strong Eyes
-    rule:
-      # TODO convert to or rule and update to include shortcut
-      ref: can_unlock_door
-  - region: Castle Main
-    entrance_name: Dungeon Top Exit
+          light_breaker: 1
+      - tags:
+          not_afraid_of_the_dark: 3
+
+regions:
+  - name: Dungeon Mirror
+    exits:
+      - region: Dungeon Slide
+        rule:
+          ref: can_attack
+  - name: Dungeon Slide
+    exits:
+      - region: Dungeon Mirror
+        rule:
+          ref: can_attack
+      - region: Dungeon Strong Eyes
+        rule:
+          has: slide
+      - region: Dungeon Escape Lower
+        rule:
+          or:
+            - and:
+              - ref: can_attack
+              - ref: can_enter_dark_rooms
+            - has: breaker
+              tags:
+                dungeon_escape: 1
+  - name: Dungeon Strong Eyes
+    exits:
+      - region: Dungeon Slide
+        rule:
+          has: slide
+      - region: Dungeon => Castle
+  - name: Dungeon => Castle  # Dungeon Top Exit
+    exits:
+      - region: Dungeon Mirror
+      - region: Dungeon Strong Eyes
+        rule:
+          # TODO convert to or rule and update to include shortcut
+          ref: can_unlock_door
+      - region: Castle Main
+        entrance_name: Dungeon Top Exit
+  - name: Dungeon Escape Lower
+    exits:
+      - region: Dungeon Slide
+        rule:
+      - region: Dungeon Escape Upper
+        rule:
+      - region: Underbelly => Dungeon
+        rule:
+  - name: Dungeon Escape Upper
+    exits:
+      - region: Dungeon Escape Lower
+        rule:
+      - region: Theatre Outside Scythe Corridor
+        rule:
+
+  - name: Castle Main
+    exits:
+      - region: Dungeon => Castle
+        rule:
+      - region: Keep Main
+        rule:
+      - region: Bailey Lower
+        rule:
+      - region: Library Main
+        rule:
+      - region: Castle => Theatre Pillar
+        rule:
+      - region: Castle Spiral Climb
+        rule:
+      - region: Keep (Northeast) => Castle
+        rule:
+  - name: Castle Spiral Climb
+    exits:
+      - region: Castle Main
+        rule:
+      - region: Castle High Climb
+        rule:
+      - region: Castle By Scythe Corridor
+        rule:
+  - name: Castle High Climb
+
+  - name: Castle By Scythe Corridor
+    exits:
+      - region: Castle Spiral Climb
+        rule:
+      - region: Castle High Climb
+        rule:
+      - region: Castle => Theatre (Front)
+        rule:
+  - name: Castle => Theatre (Front)
+    exits:
+      - region: Castle By Scythe Corridor
+        rule:
+      - region: Castle Moon Room
+        rule:
+      - region: Theatre Main
+        rule:
+  - name: Castle Moon Room
+
+
+  - name: Library Main
+    exits:
+      - region: Library Locked
+        rule:
+      - region: Library Greaves
+        rule:
+      - region: Library Top
+        rule:
+      - region: Castle Main
+        rule:
+  - name: Library Locked
+
+  - name: Library Greaves
+    exits:
+      - region: Library Back
+        rule:
+  - name: Library Top
+    exits:
+      - region: Library Back
+        rule:
+  - name: Library Back
+    exits:
+      - region: Library Greaves
+        rule:
+      - region: Library Top
+        rule:
+
+  - name: Keep Main
+    exits:
+      - region: Keep Locked Room
+        rule:
+      - region: Keep Sunsetter
+        rule:
+      - region: Keep Throne Room
+        rule:
+      - region: Keep => Underbelly
+        rule:
+      - region: Theatre Outside Scythe Corridor
+        rule:
+      - region: Keep (Northeast) => Castle
+        rule:
+      - region: Castle Main
+        rule:
+  - name: Keep Locked Room
+    exits:
+      - region: Keep Sunsetter
+        rule:
+  - name: Keep Sunsetter
+
+  - name: Keep Throne Room
+
+  - name: Keep => Underbelly
+    exits:
+      - region: Keep Main
+        rule:
+      - region: Underbelly => Keep
+        rule:
+  - name: Keep (Northeast) => Castle
+    exits:
+      - region: Keep Main
+        rule:
+      - region: Castle Main
+        rule:
+
+  - name: Bailey Lower
+    exits:
+      - region: Bailey Upper
+        rule:
+      - region: Castle Main
+        rule:
+      - region: Theatre Pillar => Bailey
+        rule:
+  - name: Bailey Upper
+    exits:
+      - region: Bailey Lower
+        rule:
+      - region: Underbelly => Bailey
+        rule:
+      - region: Tower Remains
+        rule:
+  - name: Tower Remains
+    exits:
+      - region: The Great Door
+        rule:
+
+  - name: Underbelly => Dungeon
+    exits:
+      - region: Dungeon Escape Lower
+        rule:
+      - region: Underbelly Light Pillar
+        rule:
+      - region: Underbelly Ascendant Light
+        rule:
+  - name: Underbelly Light Pillar
+    exits:
+      - region: Underbelly Main Upper
+        rule:
+      - region: Underbelly => Dungeon
+        rule:
+      - region: Underbelly Ascendant Light
+        rule:
+  - name: Underbelly Ascendant Light
+    exits:
+      - region: Underbelly => Dungeon
+        rule:
+  - name: Underbelly Main Lower
+    exits:
+      - region: Underbelly => Bailey
+        rule:
+      - region: Underbelly Hole
+        rule:
+      - region: Underbelly By Heliacal
+        rule:
+      - region: Underbelly Main Upper
+        rule:
+  - name: Underbelly Main Upper
+    exits:
+      - region: Underbelly Main Lower
+        rule:
+      - region: Underbelly Light Pillar
+        rule:
+      - region: Underbelly By Heliacal
+        rule:
+  - name: Underbelly By Heliacal
+    exits:
+      - region: Underbelly Main Upper
+        rule:
+  - name: Underbelly => Bailey
+    exits:
+      - region: Bailey Upper
+        rule:
+      - region: Bailey Lower
+        rule:
+      - region: Underbelly Main Lower
+        rule:
+  - name: Underbelly => Keep
+    exits:
+      - region: Keep => Underbelly
+        rule:
+      - region: Underbelly Hole
+        rule:
+  - name: Underbelly Hole
+    exits:
+      - region: Underbelly Main Lower
+        rule:
+      - region: Underbelly => Keep
+        rule:
+
+  - name: Theatre Main
+    exits:
+      - region: Theatre Outside Scythe Corridor
+        rule:
+      - region: Theatre Pillar
+        rule:
+      - region: Castle => Theatre (Front)
+        rule:
+  - name: Theatre Pillar => Bailey
+    exits:
+      - region: Theatre Pillar
+        rule:
+      - region: Bailey Lower
+        rule:
+  - name: Castle => Theatre Pillar
+    exits:
+      - region: Theatre Pillar
+        rule:
+      - region: Castle Main
+        rule:
+  - name: Theatre Pillar
+    exits:
+      - region: Theatre Main
+        rule:
+      - region: Theatre Pillar => Bailey
+        rule:
+      - region: Castle => Theatre Pillar
+        rule:
+  - name: Theatre Outside Scythe Corridor
+    exits:
+      - region: Theatre Main
+        rule:
+      - region: Dungeon Escape Upper
+        rule:
+      - region: Keep Main
+        rule:
+
+  - name: The Great Door
+
 
 origins:
-- spawn_point: castle_main
-  region: Castle Main
-- spawn_point: castle_gazebo
-  region: Castle Main
-- spawn_point: dungeon_mirror
-  region: Dungeon Mirror
-- spawn_point: library
-  region: Library Main
-- spawn_point: underbelly_south
-  region: Underbelly South Exit
-- spawn_point: underbelly_big_room
-  region: Underbelly Main Upper
-- spawn_point: bailey_main
-  region: Bailey Lower
-- spawn_point: keep_main
-  region: Keep Main
-- spawn_point: keep_north
-  region: Keep Main
-- spawn_point: theatre_main
-  region: Theatre Main
+  - spawn_point: castle_main
+    region: Castle Main
+  - spawn_point: castle_gazebo
+    region: Castle Main
+  - spawn_point: dungeon_mirror
+    region: Dungeon Mirror
+  - spawn_point: library
+    region: Library Main
+  - spawn_point: underbelly_south
+    region: Underbelly South Exit
+  - spawn_point: underbelly_big_room
+    region: Underbelly Main Upper
+  - spawn_point: bailey_main
+    region: Bailey Lower
+  - spawn_point: keep_main
+    region: Keep Main
+  - spawn_point: keep_north
+    region: Keep Main
+  - spawn_point: theatre_main
+    region: Theatre Main
 
 locations:
   - name: Dilapidated Dungeon - Dream Breaker

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -118,10 +118,10 @@ regions:
         has: slide
     - region: Dungeon Escape Lower
       rule:
-        ref:
-          - dungeon_escape
-          - can_attack
-        options: darkrooms
+        and:
+          - ref: dungeon_escape
+          - ref: can_attack
+          - ref: can_enter_dark_rooms
       # keeping this version for reference, but keeping the assumptions about macros consistent
       # rule:
       #   or:
@@ -141,8 +141,9 @@ regions:
         or:
         - ref: can_unlock_door
         - tags: obscure_tech
-          options: map_patch
-          or:
+          options:
+            game_version: map_patch
+        - or:
           - has: bounce
           - ref: can_attack
             has:
@@ -158,7 +159,8 @@ regions:
         or:
         - ref: can_unlock_door
         - tags: obscure_tech
-          options: map_patch
+          options:
+            game_version: map_patch
           or:
           - has: plunge
           - ref: can_attack
@@ -474,7 +476,8 @@ regions:
         - or:
           - has:
               kick_or_plunge: 4
-          - options: map_patch
+          - options:
+              game_version: map_patch
             has:
               kick: 1
               plunge: 1
@@ -496,7 +499,7 @@ regions:
     exits:
     - region: Dungeon Escape Lower
       rule:
-        options: darkrooms
+        ref: can_enter_dark_rooms
     - region: Underbelly Light Pillar
     - region: Underbelly Ascendant Light
       rule:
@@ -510,9 +513,9 @@ regions:
         - has:
             kick: 1
             slide_jump: 1
-        - ref:
-          - obscure_tech
-          - can_attack
+        - and:
+          - ref: obscure_tech
+          - ref: can_attack
   - name: Underbelly Light Pillar
     exits:
     - region: Underbelly Main Upper
@@ -830,14 +833,16 @@ locations:
       or:
       - has: breaker
       - tag: obscure_tech
-        options: map_patch
+        options:
+          game_version: map_patch
         or:
         - has:
             cling: 2
         - has: kick
         - has: plunge
       - tag: obscure_tech
-        options: full_gold
+        options:
+          game_version: full_gold
         or:
         - has:
             cling: 2

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -1172,6 +1172,20 @@ locations:
         has:
           kick: 3
           plunge: 1
+      - options:
+          difficulty: expert
+        ref: can_gold_slide_ultra
+        has: kick
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          light: 1
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          kick: 2
   - name: Dilapidated Dungeon - Past Poles
     code: 5
     region: Dungeon Strong Eyes
@@ -1202,6 +1216,11 @@ locations:
         has:
           slide_jump: 1
           kick: 1
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          kick: 1
   - name: Dilapidated Dungeon - Rafters
     code: 6
     region: Dungeon Strong Eyes
@@ -1228,6 +1247,19 @@ locations:
         has:
           kick: 1
           light: 1
+      - options:
+          difficulty: expert
+        has:
+          kick_or_plunge: 2
+      - options:
+          difficulty: expert
+        ref: can_gold_ultra
+        has: kick_or_plunge
+      - options:
+          difficulty: expert
+        has:
+          light: 1
+          cling: 2
   - name: Dilapidated Dungeon - Strong Eyes
     code: 7
     region: Dungeon Strong Eyes
@@ -1286,6 +1318,9 @@ locations:
       - has: plunge
         tags:
           old_obscure: 1
+      - options:
+          difficulty: expert
+        has: slide
   - name: Castle Sansa - Balcony
     code: 10
     region: Castle Main
@@ -1303,6 +1338,18 @@ locations:
         has:
           slide_jump: 1
           kick: 1
+      - options:
+          difficulty: expert
+        has:
+          kick: 3
+      - options:
+          difficulty: expert
+        has:
+          plunge: 1
+          kick: 1
+      - options:
+          difficulty: expert
+        has: slide
   - name: Castle Sansa - Corner Corridor
     code: 11
     region: Castle Main
@@ -1316,6 +1363,11 @@ locations:
           difficulty: hard
         has:
           kick: 3
+      - options:
+          difficulty: expert
+        has:
+          kick: 2
+          slide: 1
   - name: Castle Sansa - Floater In Courtyard
     code: 12
     region: Castle Main
@@ -1347,6 +1399,29 @@ locations:
           difficulty: hard
         has:
           cling: 4
+      - options:
+          difficulty: expert
+        has:
+          light: 1
+          slide: 1
+      - options:
+          difficulty: expert
+        ref: can_gold_ultra
+        has: kick
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          kick_or_plunge: 2
+      - options:
+          difficulty: expert
+        has:
+          kick: 3
+      - options:
+          difficulty: expert
+        has:
+          cling: 2
+
   - name: Castle Sansa - Locked Door
     code: 13
     region: Castle Main
@@ -1367,6 +1442,9 @@ locations:
       - options:
           difficulty: hard
         has: kick_or_plunge
+      - options:
+          difficulty: expert
+        has: slide
   - name: Castle Sansa - Tall Room Near Wheel Crawlers
     code: 15
     region: Castle Main
@@ -1391,6 +1469,9 @@ locations:
         has:
           slide_jump: 1
           plunge: 1
+      - options:
+          difficulty: expert
+        ref: can_gold_ultra
   - name: Castle Sansa - Wheel Crawlers
     code: 16
     region: Castle Main
@@ -1415,6 +1496,12 @@ locations:
         has:
           slide_jump: 1
           plunge: 1
+      - options:
+          difficulty: expert
+        has: kick_or_plunge
+      - options:
+          difficulty: expert
+        has: slide
   - name: Castle Sansa - High Climb From Courtyard
     code: 17
     region: Castle High Climb
@@ -1436,6 +1523,18 @@ locations:
         has:
           plunge: 1
           slide_jump: 1
+      - options:
+          difficulty: expert
+        ref: can_attack
+        has: kick
+      - options:
+          difficulty: expert
+        has:
+          cling: 2
+          kick: 1
+      - options:
+          difficulty: expert
+        has: slide
   - name: Castle Sansa - Alcove Near Scythe Corridor
     code: 18
     region: Castle By Scythe Corridor
@@ -1461,6 +1560,19 @@ locations:
         has:
           kick: 2
           plunge: 1
+      - options:
+          difficulty: expert
+        has:
+          kick_or_plunge: 3
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          kick: 1
+      - options:
+          difficulty: expert
+        ref: can_gold_ultra
+        has: plunge
   - name: Castle Sansa - Near Theatre Front
     code: 19
     region: Castle Moon Room
@@ -1480,6 +1592,18 @@ locations:
         has:
           cling: 2
           kick: 2
+      - options:
+          difficulty: expert
+        ref: can_gold_slide_ultra
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          kick: 1
+      - options:
+          difficulty: expert
+        has:
+          cling: 4
 
   - name: Sansa Keep - Strikebreak
     code: 20
@@ -1501,6 +1625,12 @@ locations:
         - options:
             difficulty: hard
           has: kick
+        - options:
+            difficulty: expert
+          has: slide
+        - options:
+            difficulty: expert
+          has: plunge
   - name: Sansa Keep - Alcove Near Locked Door
     code: 21
     region: Keep Locked Room
@@ -1520,6 +1650,9 @@ locations:
       - has: kick_or_plunge
       - has:
           cling: 2
+      - options:
+          difficulty: expert
+        has: slide
   - name: Sansa Keep - Sunsetter
     code: 25
     region: Keep Sunsetter
@@ -1544,11 +1677,13 @@ locations:
           kick_or_plunge: 1
       - has:
           kick_or_plunge: 2
-      - options:
-          difficulty: hard
-        ref: can_attack
-        has:
-          cling: 4
+        - options:
+            difficulty: hard
+          has:
+            cling: 4
+        - options:
+            difficulty: expert
+          has: slide
   - name: Listless Library - Locked Door Across
     code: 28
     region: Library Locked
@@ -1562,6 +1697,9 @@ locations:
           difficulty: hard
         has:
           kick_or_plunge: 1
+      - options:
+          difficulty: expert
+        has: slide
   - name: Listless Library - Locked Door Left
     code: 29
     region: Library Locked
@@ -1578,6 +1716,15 @@ locations:
           difficulty: hard
         has:
           kick: 2
+      - options:
+          difficulty: expert
+        has:
+          kick_or_plunge: 2
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          kick_or_plunge: 1
 
   - name: Twilight Theatre - Soul Cutter
     code: 30
@@ -1590,11 +1737,12 @@ locations:
         - has: kick_or_plunge
         - has:
             cling: 2
-      - options:
-          difficulty: hard
-        has:
-          strikebreak: 1
-          slide_jump: 1
+        - options:
+            difficulty: hard
+          has: slide_jump
+        - options:
+            difficulty: expert
+          has: slide
   - name: Twilight Theatre - Back Of Auditorium
     code: 31
     region: Theatre Main
@@ -1609,6 +1757,9 @@ locations:
       - options:
           difficulty: hard
         has: slide_jump
+      - options:
+          difficulty: expert
+        has: slide
   - name: Twilight Theatre - Center Stage
     code: 32
     region: Theatre Main
@@ -1626,6 +1777,11 @@ locations:
           cling: 6
           kick_or_plunge: 1
           slide_jump: 1
+      - options:
+          difficulty: expert
+        has:
+          cutter: 1
+          cling: 4
   - name: Twilight Theatre - Locked Door
     code: 33
     region: Theatre Main
@@ -1639,6 +1795,9 @@ locations:
             difficulty: hard
           has:
             cling: 4
+        - options:
+            difficulty: expert
+          has: slide
   - name: Twilight Theatre - Tucked Behind Boxes
     code: 34
     region: Theatre Main
@@ -1667,6 +1826,20 @@ locations:
         has:
           cling: 2
           slide_jump: 1
+      - options:
+          difficulty: expert
+        has:
+          kick: 3
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          kick_or_plunge: 2
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          cling: 2
 
   - name: Empty Bailey - Solar Wind
     code: 36
@@ -1686,6 +1859,12 @@ locations:
         has:
           kick: 2
           breaker: 1
+      - options:
+          difficulty: expert
+        has: kick
+      - options:
+          difficulty: expert
+        has: slide
   - name: Empty Bailey - Cheese Bell
     code: 38
     region: Bailey Upper
@@ -1704,6 +1883,11 @@ locations:
           difficulty: hard
         has:
           cling: 6
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          kick: 1
   - name: Empty Bailey - Guarded Hand
     code: 39
     region: Bailey Lower
@@ -1755,6 +1939,11 @@ locations:
         has:
           kick: 2
           slide_jump: 1
+      - options:
+          difficulty: expert
+        has:
+          kick: 1
+          slide: 1
   - name: The Underbelly - Building Near Little Guy
     code: 43
     region: Underbelly => Bailey
@@ -1767,6 +1956,12 @@ locations:
           difficulty: hard
         has:
           kick: 2
+      - options:
+          difficulty: expert
+        has: kick
+      - options:
+          difficulty: expert
+        has: slide
   - name: The Underbelly - Locked Door
     code: 44
     region: Underbelly By Heliacal
@@ -1791,6 +1986,12 @@ locations:
       - options:
           difficulty: hard
         has: slide_jump
+      - options:
+          difficulty: expert
+        has: slide
+      - options:
+          difficulty: expert
+        has: kick
   - name: The Underbelly - Rafters Near Keep
     code: 46
     region: Underbelly => Keep
@@ -1807,6 +2008,9 @@ locations:
           difficulty: hard
         has:
           cling: 2
+      - options:
+          difficulty: expert
+        has: slide
   - name: The Underbelly - Strikebreak Wall
     code: 47
     region: Underbelly Main Upper
@@ -1825,6 +2029,21 @@ locations:
             difficulty: hard
           has:
             kick_or_plunge: 3
+        - options:
+            difficulty: expert
+          has:
+            kick: 1
+            plunge: 1
+        - options:
+            difficulty: expert
+          has:
+            slide: 1
+            kick: 2
+        - options:
+            difficulty: expert
+          ref: can_gold_ultra
+          has:
+            cling: 2
 
   - name: The Underbelly - Surrounded By Holes
     code: 48
@@ -1847,6 +2066,17 @@ locations:
         has:
           plunge: 1
           cling: 6
+      - options:
+          difficulty: expert
+        has:
+          cutter: 1
+          slide: 1
+      - options:
+          difficulty: expert
+        has:
+          slide: 1
+          kick: 1
+          plunge: 1
 
   - name: Tower Remains - Cling Gem
     code: 49
@@ -1859,6 +2089,9 @@ locations:
           difficulty: hard
         has:
           cling: 2
+      - options:
+          difficulty: expert
+        has: slide
     can_create:
       split_cling_gem: false
   - name: Tower Remains - Atop The Tower
@@ -2003,6 +2236,9 @@ locations:
           difficulty: hard
         has:
           cling: 2
+      - options:
+          difficulty: expert
+        has: slide
     can_create:
       split_cling_gem: true
   - name: Tower Remains - Cling Gem 2
@@ -2016,6 +2252,9 @@ locations:
           difficulty: hard
         has:
           cling: 2
+      - options:
+          difficulty: expert
+        has: slide
     can_create:
       split_cling_gem: true
   - name: Tower Remains - Cling Gem 3
@@ -2029,6 +2268,9 @@ locations:
           difficulty: hard
         has:
           cling: 2
+      - options:
+          difficulty: expert
+        has: slide
     can_create:
       split_cling_gem: true
 
@@ -2093,6 +2335,9 @@ locations:
           difficulty: hard
         has:
           cling: 2
+      - options:
+          difficulty: expert
+        has: slide
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Trapped Goatling
@@ -2277,6 +2522,9 @@ locations:
           tags:
             old_obscure: 1
           has: slide_jump
+        - options:
+            difficulty: expert
+          has: slide
     can_create:
       randomize_chairs: true
 
@@ -2364,6 +2612,9 @@ locations:
       - options:
           difficulty: hard
         has: slide_jump
+      - options:
+          difficulty: expert
+        has: slide
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note in the Big Room
@@ -2386,6 +2637,13 @@ locations:
         has:
           cling: 6
           kick: 1
+      - options:
+          difficulty: expert
+        has: slide
+      - options:
+          difficulty: expert
+        has:
+          cling: 6
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note Behind a Locked Door

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -131,12 +131,32 @@ regions:
       rule:
         has: slide
     - region: Dungeon => Castle
+      rule:
+        or:
+        - ref: can_unlock_door
+        - tags: obscure_tech
+          options: map_patch
+          or:
+          - has: bounce
+          - ref: can_attack
+            has:
+              kick: 2
+          - ref: can_attack
+            has:
+              cling: 2
   - name: Dungeon => Castle
     exits:
     - region: Dungeon Mirror
     - region: Dungeon Strong Eyes
       rule:
-        ref: can_unlock_door
+        or:
+        - ref: can_unlock_door
+        - tags: obscure_tech
+          options: map_patch
+          or:
+          - has: plunge
+          - ref: can_attack
+            has: kick
     - region: Castle Main
       entrance_name: Dungeon Top Exit
   - name: Dungeon Escape Lower
@@ -263,7 +283,21 @@ regions:
     - region: Underbelly => Bailey
       rule: null
     - region: Tower Remains
-      rule: null
+      rule:
+        and:
+        - or:
+          - has:
+              kick_or_plunge: 4
+          - options: map_patch
+            has:
+              kick: 1
+              plunge: 1
+              bounce: 1
+        - or: # get onto the bridge
+          - has: slide_jump
+          - has: plunge
+            tags: obscure_knowledge
+
   - name: Tower Remains
     exits:
     - region: The Great Door
@@ -437,7 +471,26 @@ locations:
   - name: Dilapidated Dungeon - Strong Eyes
     code: 7
     region: Dungeon Strong Eyes
-    rule: null
+    rule:
+      or:
+      - has: breaker
+      - tag: obscure_tech
+        options: map_patch
+        or:
+        - has:
+            cling: 2
+        - has: kick
+        - has: plunge
+      - tag: obscure_tech
+        options: full_gold
+        or:
+        - has:
+            cling: 2
+            kick: 1
+            plunge: 1
+        - has:
+            cling: 2
+            kick: 3
 
   - name: Castle Sansa - Indignation
     code: 8

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -2182,7 +2182,7 @@ locations:
             cling: 4
         - options:
             logic_level: expert
-            has: slide
+          has: slide
       - options:
           logic_level: lunatic
         has: plunge

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -58,6 +58,9 @@ tags:
     hard: At this level, you may be required to use slide ultras purely to gain height.
     expert: At this level, you may be required to use slide ultras for distance, which can require higher speed.
     lunatic: At this level, slide ultra setups may be very precise, involving very small runway or sharp angle changes.
+  - name: old_obscure
+    off: obscure is not expected
+    on: obscure is expected
 
 tag_groups:
   - name: basic_tech
@@ -140,7 +143,8 @@ regions:
       rule:
         or:
         - ref: can_unlock_door
-        - tags: obscure_tech
+        - tags:
+            old_obscure: 1
           options:
             game_version: map_patch
         - or:
@@ -158,7 +162,8 @@ regions:
       rule:
         or:
         - ref: can_unlock_door
-        - tags: obscure_tech
+        - tags:
+            old_obscure: 1
           options:
             game_version: map_patch
           or:
@@ -192,7 +197,8 @@ regions:
         - has: kick
         - has:
             cling: 2
-        - tags: obscure_tech
+        - tags:
+            old_obscure: 1
           has: plunge
   - name: Castle Main
     exits:
@@ -222,7 +228,8 @@ regions:
       rule:  # TODO: not sure about this logic, idk where doing it with no items should go
         or:
         - ref: can_attack
-        - tag: obscure_tech
+        - tags:
+            old_obscure: 1
   - name: Castle Spiral Climb
     exits:
     - region: Castle Main
@@ -461,7 +468,8 @@ regions:
         - has:
             kick: 2
         - has: kick
-          tag: obscure_tech
+          tags:
+            old_obscure: 1
     - region: Castle Main
     - region: Theatre Pillar => Bailey
   - name: Bailey Upper
@@ -485,7 +493,8 @@ regions:
         - or: # get onto the bridge
           - has: slide_jump
           - has: plunge
-            tags: obscure_knowledge
+            tags:
+              old_obscure: 1
 
   - name: Tower Remains
     exits:
@@ -536,7 +545,8 @@ regions:
           - has: plunge
           - has:
               kick: 3
-            tag: obscure_tech
+            tags:
+              old_obscure: 1
   - name: Underbelly Ascendant Light
     exits:
     - region: Underbelly => Dungeon
@@ -674,7 +684,8 @@ regions:
         - has:
             kick: 1
             plunge: 1
-          tag: obscure_tech
+          tags:
+            old_obscure: 1
         - has:
             kick: 1
             slide_jump: 1
@@ -693,7 +704,8 @@ regions:
       rule:
         or:
         - has: plunge
-          tags: obscure_tech
+          tags:
+            old_obscure: 1
         - has:
             kick: 1
             bounce: 1
@@ -736,7 +748,8 @@ regions:
         - has:
             cling: 2
         - has: slide_jump
-        - tags: obscure_tech
+        - tags:
+            old_obscure: 1
           has: plunge
     - region: Keep Main
       rule:
@@ -746,7 +759,8 @@ regions:
         - has: kick
         - has: bounce
         - has: slide_jump
-        - tags: obscure_tech
+        - tags:
+            old_obscure: 1
           has: plunge
   - name: The Great Door
 
@@ -814,7 +828,8 @@ locations:
       - has:
           slide_jump: 1
           kick: 2
-          tags: obscure
+          tags:
+            old_obscure: 1
   - name: Dilapidated Dungeon - Rafters
     code: 6
     region: Dungeon Strong Eyes
@@ -825,14 +840,16 @@ locations:
       - has:
           bounce: 1
           plunge: 1
-          tags: obscure
+          tags:
+            old_obscure: 1
   - name: Dilapidated Dungeon - Strong Eyes
     code: 7
     region: Dungeon Strong Eyes
     rule:
       or:
       - has: breaker
-      - tag: obscure_tech
+      - tags:
+          old_obscure: 1
         options:
           game_version: map_patch
         or:
@@ -840,7 +857,8 @@ locations:
             cling: 2
         - has: kick
         - has: plunge
-      - tag: obscure_tech
+      - tags:
+          old_obscure: 1
         options:
           game_version: full_gold
         or:
@@ -865,7 +883,8 @@ locations:
       - has: kick
       - has: slide_jump
       - has: plunge
-        tags: obscure
+        tags:
+          old_obscure: 1
   - name: Castle Sansa - Balcony
     code: 10
     region: Castle Main
@@ -903,7 +922,8 @@ locations:
       - has:
           bounce: 1
           kick: 1
-          tags: obscure
+          tags:
+            old_obscure: 1
   - name: Castle Sansa - Locked Door
     code: 13
     region: Castle Main
@@ -945,7 +965,8 @@ locations:
           kick: 1
           slide_jump: 1
       - has: plunge
-        tags: obscure
+        tags:
+          old_obscure: 1
   - name: Castle Sansa - High Climb From Courtyard
     code: 17
     region: Castle High Climb
@@ -1079,7 +1100,8 @@ locations:
     rule:
       or:
       - has: plunge
-        tags: obscure
+        tags:
+          old_obscure: 1
       - has: kick
       - has:
           cling: 2
@@ -1115,7 +1137,8 @@ locations:
       - has:
           plunge: 1
           kick: 3
-          tags: obscure  # use crouch backflip
+          tags:
+            old_obscure: 1  # use crouch backflip
       - has:
           kick: 4
 
@@ -1154,7 +1177,8 @@ locations:
               cling: 2
           - has:
               kick: 3
-          - tag: obscure_tech
+          - tags:
+              old_obscure: 1
       - and:
         - has: breaker
         - or:
@@ -1205,7 +1229,8 @@ locations:
       - has:
           slide_jump: 1
           kick: 1
-      - tag: obscure_tech
+      - tags:
+          old_obscure: 1
         or:
         - has:
             cling: 2
@@ -1241,7 +1266,8 @@ locations:
         - has:
             kick: 2
         - has: kick
-          tag: obscure_tech
+          tags:
+            old_obscure: 1
 
   - name: Tower Remains - Cling Gem
     code: 49
@@ -1289,7 +1315,7 @@ locations:
         slide_jump: 1
     can_create:
       game_version: map_patch
-      randomize_time_trials: True
+      randomize_time_trials: true
   - name: Castle Sansa - Time Trial
     code: 55
     region: Castle Main
@@ -1297,7 +1323,7 @@ locations:
       ref: can_unlock_door
     can_create:
       game_version: map_patch
-      randomize_time_trials: True
+      randomize_time_trials: true
   - name: Sansa Keep - Time Trial
     code: 56
     region: Keep Throne Room
@@ -1311,7 +1337,7 @@ locations:
         bounce: 1
     can_create:
       game_version: map_patch
-      randomize_time_trials: True
+      randomize_time_trials: true
   - name: Listless Library - Time Trial
     code: 57
     region: Library Main
@@ -1322,7 +1348,7 @@ locations:
         kick: 3
     can_create:
       game_version: map_patch
-      randomize_time_trials: True
+      randomize_time_trials: true
   - name: Twilight Theatre - Time Trial
     code: 58
     region: Theatre Pillar
@@ -1335,7 +1361,7 @@ locations:
         slide_jump: 1
     can_create:
       game_version: map_patch
-      randomize_time_trials: True
+      randomize_time_trials: true
   - name: Empty Bailey - Time Trial
     code: 59
     region: Bailey Upper
@@ -1348,7 +1374,7 @@ locations:
         slide_jump: 1
     can_create:
       game_version: map_patch
-      randomize_time_trials: True
+      randomize_time_trials: true
   - name: The Underbelly - Time Trial
     code: 60
     region: Underbelly Main Upper
@@ -1361,7 +1387,7 @@ locations:
         slide_jump: 1
     can_create:
       game_version: map_patch
-      randomize_time_trials: True
+      randomize_time_trials: true
   - name: Tower Remains - Time Trial
     code: 61
     region: The Great Door
@@ -1374,7 +1400,7 @@ locations:
         slide_jump: 1
     can_create:
       game_version: map_patch
-      randomize_time_trials: True
+      randomize_time_trials: true
 
   - name: Castle Sansa - Memento
     code: 62
@@ -1459,7 +1485,8 @@ locations:
           - has: kick
           - has: bounce
           - has: slide_jump
-          - tags: obscure
+          - tags:
+              old_obscure: 1
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Trapped Goatling
@@ -1473,13 +1500,13 @@ locations:
     code: 75
     region: Castle Main
     can_create:
-      randomize_goats: True
+      randomize_goats: true
       game_version: map_patch
   - name: Castle Sansa - Goatling Near Library
     code: 76
     region: Castle Main
     can_create:
-      randomize_goats: True
+      randomize_goats: true
       game_version: map_patch
   - name: Sansa Keep - Furniture-less Goatling
     code: 77
@@ -1521,7 +1548,8 @@ locations:
       - has:
           kick: 1
           plunge: 1
-          tags: obscure
+          tags:
+            old_obscure: 1
       - has:
           kick: 1
           slide_jump: 1
@@ -1628,11 +1656,13 @@ locations:
         - has:
             slide_jump: 1
             plunge: 1
-            tags: obscure
+            tags:
+              old_obscure: 1
         - has:
             slide_jump: 1
             bounce: 1
-            tags: obscure
+            tags:
+              old_obscure: 1
     can_create:
       randomize_chairs: true
 

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -173,6 +173,11 @@ regions:
           has:
             breaker: 1
             slide_jump: 1
+      - options:
+          game_version: map_patch
+          difficulty: expert
+        ref: can_attack
+        has: slide
   - name: Dungeon => Castle
     exits:
     - region: Dungeon Mirror
@@ -195,6 +200,12 @@ regions:
           has:
             breaker: 1
             cling: 2
+      - options:
+          game_version: map_patch
+          difficulty: expert
+        has:
+          breaker: 1
+          slide: 1
     - region: Castle Main
       entrance_name: Dungeon Top Exit
   - name: Dungeon Escape Lower
@@ -671,7 +682,20 @@ regions:
           has:
             kick: 2
             light: 1
-
+      - options:
+          game_version: map_patch
+          difficulty: expert
+        and:
+        - has: slide
+        - or:
+          - has: light
+          - has: kick
+          - has:
+              cling: 2
+      - options:
+          game_version: full_gold
+          difficulty: expert
+        has: slide
 
   - name: Tower Remains
     exits:
@@ -1231,6 +1255,21 @@ locations:
         - has:
             cling: 2
             kick: 3
+      - options:
+          game_version: map_patch
+          difficulty: expert
+        has: slide
+      - options:
+          game_version: full_gold
+          difficulty: expert
+        has:
+          cling: 2
+      - options:
+          game_version: full_gold
+          difficulty: expert
+        has:
+          slide: 1
+          kick: 1
 
   - name: Castle Sansa - Indignation
     code: 8

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -414,554 +414,671 @@ locations:
   - name: Dilapidated Dungeon - Dream Breaker
     code: 1
     region: Dungeon Mirror
+    rule:
     
   - name: Dilapidated Dungeon - Slide
     code: 2
     region: Dungeon Slide
+    rule:
     
   - name: Dilapidated Dungeon - Alcove Near Mirror
     code: 3
     region: Dungeon => Castle
+    rule:
     
   - name: Dilapidated Dungeon - Dark Orbs
     code: 4
     region: Dungeon Escape Upper
+    rule:
     
   - name: Dilapidated Dungeon - Past Poles
     code: 5
     region: Dungeon Strong Eyes
+    rule:
     
   - name: Dilapidated Dungeon - Rafters
     code: 6
     region: Dungeon Strong Eyes
+    rule:
     
   - name: Dilapidated Dungeon - Strong Eyes
     code: 7
     region: Dungeon Strong Eyes
+    rule:
     
 
   - name: Castle Sansa - Indignation
     code: 8
     region: Castle Main
+    rule:
     
   - name: Castle Sansa - Alcove Near Dungeon
     code: 9
     region: Castle => Theatre Pillar
+    rule:
     
   - name: Castle Sansa - Balcony
     code: 10
     region: Castle Main
+    rule:
     
   - name: Castle Sansa - Corner Corridor
     code: 11
     region: Castle Main
+    rule:
     
   - name: Castle Sansa - Floater In Courtyard
     code: 12
     region: Castle Main
+    rule:
     
   - name: Castle Sansa - Locked Door
     code: 13
     region: Castle Main
+    rule:
     can_create:
       game_version: FULL_GOLD
   - name: Castle Sansa - Platform In Main Halls
     code: 14
     region: Castle Main
+    rule:
     
   - name: Castle Sansa - Tall Room Near Wheel Crawlers
     code: 15
     region: Castle Main
+    rule:
     
   - name: Castle Sansa - Wheel Crawlers
     code: 16
     region: Castle Main
+    rule:
     
   - name: Castle Sansa - High Climb From Courtyard
     code: 17
     region: Castle High Climb
+    rule:
     
   - name: Castle Sansa - Alcove Near Scythe Corridor
     code: 18
     region: Castle By Scythe Corridor
+    rule:
     
   - name: Castle Sansa - Near Theatre Front
     code: 19
     region: Castle Moon Room
+    rule:
     
 
   - name: Sansa Keep - Strikebreak
     code: 20
     region: Keep Main
+    rule:
     
   - name: Sansa Keep - Alcove Near Locked Door
     code: 21
     region: Keep Locked Room
+    rule:
     
   - name: Sansa Keep - Levers Room
     code: 22
     region: Keep Main
+    rule:
     
   - name: Sansa Keep - Lonely Throne
     code: 23
     region: Keep Throne Room
+    rule:
     
   - name: Sansa Keep - Near Theatre
     code: 24
     region: Keep Main
+    rule:
     
   - name: Sansa Keep - Sunsetter
     code: 25
     region: Keep Sunsetter
+    rule:
     
 
   - name: Listless Library - Sun Greaves
     code: 26
     region: Library Greaves
+    rule:
     can_create:
       split_sun_greaves: false
   - name: Listless Library - Upper Back
     code: 27
     region: Library Top
+    rule:
     
   - name: Listless Library - Locked Door Across
     code: 28
     region: Library Locked
+    rule:
     
   - name: Listless Library - Locked Door Left
     code: 29
     region: Library Locked
+    rule:
     
 
   - name: Twilight Theatre - Soul Cutter
     code: 30
     region: Theatre Main
+    rule:
     
   - name: Twilight Theatre - Back Of Auditorium
     code: 31
     region: Theatre Main
+    rule:
     
   - name: Twilight Theatre - Center Stage
     code: 32
     region: Theatre Main
+    rule:
     
   - name: Twilight Theatre - Locked Door
     code: 33
     region: Theatre Main
+    rule:
     
   - name: Twilight Theatre - Tucked Behind Boxes
     code: 34
     region: Theatre Main
+    rule:
     
   - name: Twilight Theatre - Corner Beam
     code: 35
     region: Theatre Pillar
+    rule:
     
 
   - name: Empty Bailey - Solar Wind
     code: 36
     region: Bailey Lower
+    rule:
     
   - name: Empty Bailey - Center Steeple
     code: 37
     region: Bailey Upper
+    rule:
     
   - name: Empty Bailey - Cheese Bell
     code: 38
     region: Bailey Upper
+    rule:
     
   - name: Empty Bailey - Guarded Hand
     code: 39
     region: Bailey Lower
+    rule:
     
   - name: Empty Bailey - Inside Building
     code: 40
     region: Bailey Lower
+    rule:
     
 
   - name: The Underbelly - Ascendant Light
     code: 41
     region: Underbelly Ascendant Light
+    rule:
     
   - name: The Underbelly - Alcove Near Light
     code: 42
     region: Underbelly Light Pillar
+    rule:
     
   - name: The Underbelly - Building Near Little Guy
     code: 43
     region: Underbelly => Bailey
+    rule:
     
   - name: The Underbelly - Locked Door
     code: 44
     region: Underbelly By Heliacal
+    rule:
     
   - name: The Underbelly - Main Room
     code: 45
     region: Underbelly Main Upper
+    rule:
     
   - name: The Underbelly - Rafters Near Keep
     code: 46
     region: Underbelly => Keep
+    rule:
     
   - name: The Underbelly - Strikebreak Wall
     code: 47
     region: Underbelly Main Upper
+    rule:
     
   - name: The Underbelly - Surrounded By Holes
     code: 48
     region: Underbelly Hole
+    rule:
     
 
   - name: Tower Remains - Cling Gem
     code: 49
     region: Tower Remains
+    rule:
     can_create:
       split_cling_gem: false
   - name: Tower Remains - Atop The Tower
     code: 50
     region: The Great Door
+    rule:
     
 
   - name: Listless Library - Sun Greaves 1
     code: 51
     region: Library Greaves
+    rule:
     can_create:
       split_sun_greaves: true
   - name: Listless Library - Sun Greaves 2
     code: 52
     region: Library Greaves
+    rule:
     can_create:
       split_sun_greaves: true
   - name: Listless Library - Sun Greaves 3
     code: 53
     region: Library Greaves
+    rule:
     can_create:
       split_sun_greaves: true
 
   - name: Dilapidated Dungeon - Time Trial
     code: 54
     region: Dungeon Mirror
+    rule:
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Castle Sansa - Time Trial
     code: 55
     region: Castle Main
+    rule:
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Sansa Keep - Time Trial
     code: 56
     region: Keep Throne Room
+    rule:
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Listless Library - Time Trial
     code: 57
     region: Library Main
+    rule:
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Twilight Theatre - Time Trial
     code: 58
     region: Theatre Pillar
+    rule:
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Empty Bailey - Time Trial
     code: 59
     region: Bailey Upper
+    rule:
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: The Underbelly - Time Trial
     code: 60
     region: Underbelly Main Upper
+    rule:
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Tower Remains - Time Trial
     code: 61
     region: The Great Door
+    rule:
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
 
   - name: Castle Sansa - Memento
     code: 62
     region: Castle Main
+    rule:
     can_create:
       game_version: MAP_PATCH
 
   - name: Tower Remains - Cling Gem 1
     code: 63
     region: Tower Remains
+    rule:
     can_create:
       split_cling_gem: true
   - name: Tower Remains - Cling Gem 2
     code: 64
     region: Tower Remains
+    rule:
     can_create:
       split_cling_gem: true
   - name: Tower Remains - Cling Gem 3
     code: 65
     region: Tower Remains
+    rule:
     can_create:
       split_cling_gem: true
 
   - name: Dilapidated Dungeon - Mirror Room Goatling
     code: 66
     region: Dungeon Mirror
+    rule:
     can_create:
       randomize_goats: true
   - name: Dilapidated Dungeon - Rambling Goatling
     code: 67
     region: Dungeon Mirror
+    rule:
     can_create:
       randomize_goats: true
   - name: Dilapidated Dungeon - Unwelcoming Goatling
     code: 68
     region: Dungeon Strong Eyes
+    rule:
     can_create:
       randomize_goats: true
   - name: Dilapidated Dungeon - Repentant Goatling
     code: 69
     region: Dungeon Strong Eyes
+    rule:
     can_create:
       randomize_goats: true
   - name: Dilapidated Dungeon - Defeatist Goatling
     code: 70
     region: Dungeon Strong Eyes
+    rule:
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Crystal Licker Goatling
     code: 71
     region: Castle Main
+    rule:
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Gazebo Goatling
     code: 72
     region: Castle Main
+    rule:
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Bubblephobic Goatling
     code: 73
     region: Castle Main
+    rule:
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Trapped Goatling
     code: 74
     region: Castle By Scythe Corridor
+    rule:
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Memento Goatling
     code: 75
     region: Castle Main
+    rule:
     can_create:
       randomize_goats and options.game_version: MAP_PATCH
   - name: Castle Sansa - Goatling Near Library
     code: 76
     region: Castle Main
+    rule:
     can_create:
       randomize_goats and options.game_version: MAP_PATCH
   - name: Sansa Keep - Furniture-less Goatling
     code: 77
     region: Keep Main
+    rule:
     can_create:
       randomize_goats: true
   - name: Sansa Keep - Distorted Goatling
     code: 78
     region: Keep (Northeast) => Castle
+    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - 20 Bean Casserole Goatling
     code: 79
     region: Castle => Theatre (Front)
+    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - Theatre Goer Goatling 1
     code: 80
     region: Castle => Theatre (Front)
+    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - Theatre Goer Goatling 2
     code: 81
     region: Castle => Theatre (Front)
+    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - Theatre Manager Goatling
     code: 82
     region: Castle => Theatre (Front)
+    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - Murderous Goatling
     code: 83
     region: Theatre Main
+    rule:
     can_create:
       randomize_goats: true
   - name: Empty Bailey - Alley Goatling
     code: 84
     region: Bailey Lower
+    rule:
     can_create:
       randomize_goats: true
 
   - name: Castle Sansa - Stool Near Crystal 1
     code: 85
     region: Castle Main
+    rule:
     can_create:
       randomize_chairs: true
   - name: Castle Sansa - Stool Near Crystal 2
     code: 86
     region: Castle Main
+    rule:
     can_create:
       randomize_chairs: true
   - name: Castle Sansa - Stool Near Crystal 3
     code: 87
     region: Castle Main
+    rule:
     can_create:
       randomize_chairs: true
   - name: Castle Sansa - Gazebo Stool
     code: 88
     region: Castle Main
+    rule:
     can_create:
       randomize_chairs: true
   - name: Sansa Keep - Distorted Stool
     code: 89
     region: Keep (Northeast) => Castle
+    rule:
     can_create:
       randomize_chairs: true
   - name: Sansa Keep - Path to Throne Stool
     code: 90
     region: Keep Throne Room
+    rule:
     can_create:
       randomize_chairs: true
   - name: Sansa Keep - The Throne
     code: 91
     region: Keep Throne Room
+    rule:
     can_create:
       randomize_chairs: true
   - name: Listless Library - Hay Bale Near Entrance
     code: 92
     region: Library Main
+    rule:
     can_create:
       randomize_chairs: true
   - name: Listless Library - Hay Bale Near Eggs
     code: 93
     region: Library Top
+    rule:
     can_create:
       randomize_chairs: true
   - name: Listless Library - Hay Bale in the Back
     code: 94
     region: Library Back
+    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stool Near Bookcase
     code: 95
     region: Theatre Outside Scythe Corridor
+    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stool Around a Table 1
     code: 96
     region: Theatre Outside Scythe Corridor
+    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stool Around a Table 2
     code: 97
     region: Theatre Outside Scythe Corridor
+    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stool Around a Table 3
     code: 98
     region: Theatre Outside Scythe Corridor
+    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stage Left Stool
     code: 99
     region: Theatre Main
+    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stage Right Stool
     code: 100
     region: Theatre Main
+    rule:
     can_create:
       randomize_chairs: true
 
   - name: Listless Library - A Book About a Princess
     code: 101
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Cooking
     code: 102
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book Full of Plays
     code: 103
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Reading
     code: 104
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Aquatic Life
     code: 105
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Jester
     code: 106
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Loss
     code: 107
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book on Musical Theory
     code: 108
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Girl
     code: 109
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Thimble
     code: 110
     region: Library Main
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Monster
     code: 111
     region: Library Greaves
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Revenge
     code: 112
     region: Library Greaves
+    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Restaurant
     code: 113
     region: Library Top
+    rule:
     can_create:
       randomize_books: true
 
   - name: Listless Library - Note Near Eggs
     code: 114
     region: Library Top
+    rule:
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note on a Ledge
     code: 115
     region: Underbelly => Bailey
+    rule:
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note in the Big Room
     code: 116
     region: Underbelly Main Lower
+    rule:
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note Behind a Locked Door
     code: 117
     region: Underbelly By Heliacal
+    rule:
     can_create:
       randomize_notes: true
 

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -703,7 +703,7 @@ locations:
       - has:
           plunge: 1
           kick: 3
-          tags: obscure
+          tags: obscure  # use crouch backflip
       - has:
           kick: 4
 
@@ -711,7 +711,7 @@ locations:
     code: 36
     region: Bailey Lower
     rule:
-      has: slide
+      has: slide  # to consider: damage boosting w/ crouch
   - name: Empty Bailey - Center Steeple
     code: 37
     region: Bailey Upper
@@ -723,7 +723,7 @@ locations:
   - name: Empty Bailey - Cheese Bell
     code: 38
     region: Bailey Upper
-    rule:
+    rule:  # TODO consider to/from center steeple
       or:
       - has:
           kick: 4
@@ -836,7 +836,7 @@ locations:
     region: Tower Remains
     rule:
       has:
-        kick_or_plunge: 2
+        kick_or_plunge: 2  # climb the right tower and cross
     can_create:
       split_cling_gem: false
   - name: Tower Remains - Atop The Tower

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -154,6 +154,25 @@ regions:
           - ref: can_attack
             has:
               cling: 2
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          has: plunge
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          has:
+            breaker: 1
+            kick: 1
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          has:
+            breaker: 1
+            slide_jump: 1
   - name: Dungeon => Castle
     exits:
     - region: Dungeon Mirror
@@ -169,6 +188,13 @@ regions:
           - has: plunge
           - ref: can_attack
             has: kick
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          has:
+            breaker: 1
+            cling: 2
     - region: Castle Main
       entrance_name: Dungeon Top Exit
   - name: Dungeon Escape Lower
@@ -185,6 +211,14 @@ regions:
             plunge: 1
         - has:
             kick: 3
+        - options:
+            difficulty: hard
+          has:
+            cling: 4
+        - options:
+            difficulty: hard
+          has:
+            kick_or_plunge: 2
     - region: Underbelly => Dungeon
   - name: Dungeon Escape Upper
     exits:
@@ -215,6 +249,13 @@ regions:
             kick_or_plunge: 1
         - has:
             kick_or_plunge: 2
+        - options:
+            difficulty: hard
+          has:
+            cling: 2
+        - options:
+            difficulty: hard
+          - has: kick
     - region: Castle Spiral Climb
       rule:
         or:
@@ -222,6 +263,19 @@ regions:
             kick: 2
         - has:
             cling: 2
+            plunge: 1
+        - options:
+            difficulty: hard
+          has:
+            cling: 2
+        - options:
+            difficulty: hard
+          has:
+            kick_or_plunge: 2
+        - options:
+            difficulty: hard
+          has:
+            slide_jump: 1
             plunge: 1
     - region: Keep (Northeast) => Castle
       rule:  # TODO: not sure about this logic, idk where doing it with no items should go
@@ -242,6 +296,16 @@ regions:
             plunge: 1
         - ref: can_attack
           has: kick
+        - options:
+            difficulty: hard
+          has:
+            kick_or_plunge: 3
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          reg: can_attack
+          has: slide_jump
     - region: Castle By Scythe Corridor
       rule:
         has:
@@ -258,6 +322,10 @@ regions:
         - has:
             kick: 4
             plunge: 1
+        - options:
+            difficulty: hard
+          has:
+            kick: 3
     - region: Castle High Climb
       rule:
         or:
@@ -272,11 +340,25 @@ regions:
             kick: 1
             plunge: 1
             slide_jump: 1
+        - options:
+            difficulty: hard
+          has:
+            kick: 3
+            breaker: 1
+        - options:
+            difficulty: hard
+          has:
+            kick: 1
+            plunge: 1
     - region: Castle => Theatre (Front)
       rule:
         has:
           cling: 4
           kick_or_plunge: 2
+        - options:
+            difficulty: hard
+          has:
+            cling: 6
   - name: Castle => Theatre (Front)
     exits:
     - region: Castle By Scythe Corridor
@@ -297,6 +379,10 @@ regions:
         - has:
             slide_jump: 1
             kick_or_plunge: 2
+        - options:
+            difficulty: hard
+          has:
+            kick: 4
     - region: Theatre Main
       rule:
         or:
@@ -305,6 +391,10 @@ regions:
             kick: 1
         - has:
             kick: 2
+        - options:
+            difficulty: hard
+          has:
+            kick: 4  # TODO double check for hard logic
   - name: Castle Moon Room
 
 
@@ -326,6 +416,16 @@ regions:
           has:
             kick: 1
             plunge: 1
+        - options:
+            difficulty: hard
+          has:
+            cling: 4
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          has:
+            kick_or_plunge: 2
     - region: Castle Main
       rule:
         ref: can_attack
@@ -341,6 +441,10 @@ regions:
             cling: 2
         - has:
             kick: 2
+        - options:
+            difficulty: hard
+          ref: can_attack
+          has: kick
   - name: Library Top
     exits:
     - region: Library Back
@@ -354,6 +458,20 @@ regions:
             plunge: 1
         - has:
             kick: 3
+            light: 1
+        - options:
+            difficulty: hard
+          has:
+            cling: 2
+        - options:
+            difficulty: hard
+          has:
+            kick: 3
+        - options:
+            difficulty: hard
+          has:
+            kick: 2
+            plunge: 1
             light: 1
   - name: Library Back
     exits:
@@ -372,6 +490,13 @@ regions:
             cling: 4
         - has:
             kick: 2
+        - options:
+            difficulty: hard
+          has: kick
+        - options:
+            difficulty: hard
+          has:
+            cling: 2
   - name: Keep Main
     exits:
     - region: Keep Locked Room
@@ -389,6 +514,8 @@ regions:
         - has:
             cling: 2
             kick: 1
+        - options:
+            difficulty: hard
       # Note for trackers: This is accessible with nothing but not in logic.
       # Cutting the platform or hitting the lever make this harder and are irreversible.
       # On Hard and above, the player is expected to not do either.
@@ -398,6 +525,8 @@ regions:
           cling: 2
           # See "Keep Main -> Keep Locked Room".
           # All other methods would go through Keep Locked Room instead.
+        - options:
+            difficulty: hard
     - region: Keep Throne Room
       rule:
         or:
@@ -418,6 +547,30 @@ regions:
         - has:
             light: 1
             kick_or_plunge: 4
+        - options:
+            difficulty: hard
+          and:
+          - has:
+              breaker: 1
+              cling: 6
+            or:
+            - has: plunge
+            - has:
+                kick: 2
+            - tags:
+                old_obscure: 1
+              has: kick
+        - options:
+            difficulty: hard
+          has:
+            breaker: 1
+            plunge: 1
+            kick: 4
+        - options:
+            difficulty: hard
+          has:
+            light: 1
+            kick: 3
     - region: Keep => Underbelly
       rule:
         or:
@@ -443,6 +596,9 @@ regions:
         - has:
             kick: 2
         - has: plunge
+        - options:
+            difficulty: hard
+          has: kick
     - region: Castle Main
   - name: Keep Locked Room
     exits:
@@ -471,6 +627,13 @@ regions:
         - has: kick
           tags:
             old_obscure: 1
+        - options:
+            difficulty: hard
+          has: plunge
+        - options:
+            difficulty: hard
+          has:
+            cling: 2
     - region: Castle Main
     - region: Theatre Pillar => Bailey
   - name: Bailey Upper
@@ -481,30 +644,49 @@ regions:
         has: plunge
     - region: Tower Remains
       rule:
-        and:
-        - or:
-          - has:
-              kick_or_plunge: 4
-          - options:
-              game_version: map_patch
-            has:
-              kick: 1
-              plunge: 1
-              light: 1
-        - or: # get onto the bridge
-          - has: slide_jump
-          - has: plunge
-            tags:
-              old_obscure: 1
+        or:
+        - and:
+          - or:
+            - has:
+                kick_or_plunge: 4
+            - options:
+                game_version: map_patch
+              has:
+                kick: 1
+                plunge: 1
+                light: 1
+          - or: # get onto the bridge
+            - has: slide_jump
+            - has: plunge
+              tags:
+                old_obscure: 1
+        - options:
+            difficulty: hard
+            game_version: map_patch
+          has:
+            kick_or_plunge: 3
+        - options:
+            difficulty: hard
+            game_version: map_patch
+          has:
+            kick: 2
+            light: 1
+
 
   - name: Tower Remains
     exits:
     - region: The Great Door
       rule:
-        ref: can_attack
-        has:
-          cling: 2
-          kick_or_plunge: 1
+        or:
+        - ref: can_attack
+          has:
+            cling: 2
+            kick_or_plunge: 1
+        - options:
+            difficulty: hard
+          ref: can_attack
+          has:
+            cling: 2
   - name: Underbelly => Dungeon
     exits:
     - region: Dungeon Escape Lower
@@ -527,6 +709,10 @@ regions:
           - tags:
               old_obscure: 1
           - ref: can_attack
+        - options:
+            difficulty: hard
+          has:
+            cling: 2
   - name: Underbelly Light Pillar
     exits:
     - region: Underbelly Main Upper
@@ -541,14 +727,29 @@ regions:
       # since it's possible to use AL to go up the pillar and get to the item that way (i.e. passing through
       # Underbelly => Dungeon), the logic for this entrance is written assuming the player doesn't have AL
       rule:
-        and:
-        - has: breaker
-        - or:
-          - has: plunge
-          - has:
-              kick: 3
-            tags:
-              old_obscure: 1
+        or:
+        - and:
+          - has: breaker
+          - or:
+            - has: plunge
+            - has:
+                kick: 3
+              tags:
+                old_obscure: 1
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          ref: can_attack
+          has:
+            kick: 2
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          has:
+            plunge: 1
+            cling: 2
   - name: Underbelly Ascendant Light
     exits:
     - region: Underbelly => Dungeon
@@ -567,17 +768,28 @@ regions:
     - region: Underbelly => Bailey
     - region: Underbelly Hole
       rule:
-        and:
-        - has: plunge
-        - or:
-          - has: kick
-          - has: slide_jump
-          - ref: can_attack
+        or:
+        - and:
+          - has: plunge
+          - or:
+            - has: kick
+            - has: slide_jump
+            - ref: can_attack
+        - options:
+            difficulty: hard
+          has:
+            plunge: 1
+            cling: 4
     - region: Underbelly By Heliacal
       rule:
         has:
           slide: 1
           plunge: 1
+        - options:
+            difficulty: hard
+          has:
+            slide: 1
+            kick: 2
     - region: Underbelly Main Upper
       rule:
         tags:
@@ -585,6 +797,20 @@ regions:
         has:
           plunge: 1
           kick: 2
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          or:
+          - has:
+              plunge: 1
+              kick: 1
+          - has:
+              plunge: 1
+              cling: 4
+          - has:
+              kick: 2
+              cling: 2
   - name: Underbelly Main Upper
     exits:
     - region: Underbelly Main Lower
@@ -604,6 +830,19 @@ regions:
             - has:
                 cling: 2
                 kick: 1
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          has:
+            breaker: 1
+            cling: 2
+        - options:
+            difficulty: hard
+          has:
+            slide_jump: 1
+            kick: 1
+            plunge: 1
     - region: Underbelly By Heliacal
       rule:
         and:
@@ -633,6 +872,21 @@ regions:
           - has: kick
           - has:
               cling: 2
+        - options:
+            difficulty: hard
+          and:
+          - has: breaker
+          - or:
+            - has: light
+            - has:
+                cling: 2
+                kick_or_plunge: 1
+            - has:
+                kick_or_plunge: 4
+            - tags:
+                old_obscure: 1
+              has:
+                cling: 4
   - name: Underbelly => Bailey
     exits:
     - region: Bailey Upper
@@ -643,6 +897,15 @@ regions:
         - has:
             plunge: 1
             kick: 1
+        - options:
+            difficulty: hard
+          has:
+            kick: 3
+        - options:
+            difficulty: hard
+          has:
+            slide_jump: 1
+            kick: 1
     - region: Bailey Lower
     - region: Underbelly Main Lower
       rule:
@@ -652,6 +915,10 @@ regions:
             kick: 2
         - tags:
             old_obscure: 1
+        - options:
+            difficulty: hard
+          has:
+            cling: 2
   - name: Underbelly => Keep
     exits:
     - region: Keep => Underbelly
@@ -672,6 +939,16 @@ regions:
           - has:
               slide_jump: 1
               kick: 1
+        - options:
+            difficulty: hard
+          has:
+            plunge: 1
+            kick: 1
+        - options:
+            difficulty: hard
+          has:
+            plunge: 1
+            cling: 4
     - region: Underbelly => Keep
       rule:
         has:
@@ -681,8 +958,13 @@ regions:
     exits:
     - region: Theatre Outside Scythe Corridor
       rule:
-        has:
-          cling: 6
+        or:
+        - has:
+            cling: 6
+        - options:
+            difficulty: hard
+          has:
+            cling: 4
     - region: Theatre Pillar
       rule:
         or:
@@ -698,6 +980,9 @@ regions:
             slide_jump: 1
         - has:
             cling: 2
+        - options:
+            difficulty: hard
+          has: kick
     - region: Castle => Theatre (Front)
       rule:
         or:
@@ -716,12 +1001,24 @@ regions:
         - has:
             kick: 1
             light: 1
+        - options:
+            difficulty: hard
+          has:
+            kick: 1
+        - options:
+            difficulty: hard
+          has:
+            slide_jump: 1
     - region: Bailey Lower
   - name: Castle => Theatre Pillar
     exits:
     - region: Theatre Pillar
-      rule:
-        has: plunge
+      or:
+      - rule:
+          has: plunge
+      - options:
+         difficulty: hard
+        has: slide_jump
     - region: Castle Main
   - name: Theatre Pillar
     exits:
@@ -733,6 +1030,11 @@ regions:
         - has:
             plunge: 1
             kick: 3
+        - options:
+            difficulty: hard
+          has:
+            slide_jump: 1
+            kick_or_plunge: 3
     - region: Theatre Pillar => Bailey
     - region: Castle => Theatre Pillar
   - name: Theatre Outside Scythe Corridor
@@ -746,6 +1048,10 @@ regions:
         - has:
             cling: 6
             slide_jump: 1
+        - options:
+            difficulty: hard
+          has:
+            cling: 4
     - region: Dungeon Escape Upper
       rule:
         ref: can_enter_darkrooms
@@ -822,6 +1128,26 @@ locations:
           slide_jump: 1
           kick: 1
           light: 1
+      - options:
+          difficulty: hard
+        has:
+          cling: 6
+      - options:
+          difficulty: hard
+        has:
+          kick: 1
+          light: 1
+      - options:
+          difficulty: hard
+        has:
+          slide_jump: 1
+          plunge: 1
+          light: 1
+      - options:
+          difficulty: hard
+        has:
+          kick: 3
+          plunge: 1
   - name: Dilapidated Dungeon - Past Poles
     code: 5
     region: Dungeon Strong Eyes
@@ -837,6 +1163,21 @@ locations:
           kick: 2
         tags:
           old_obscure: 1
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
+      - options:
+          difficulty: hard
+        has:
+          kick: 2
+      - options:
+          difficulty: hard
+        tags:
+          old_obscure: 1
+        has:
+          slide_jump: 1
+          kick: 1
   - name: Dilapidated Dungeon - Rafters
     code: 6
     region: Dungeon Strong Eyes
@@ -1101,6 +1442,11 @@ locations:
         - has: kick_or_plunge
         - has:
             cling: 2
+      - options:
+          difficulty: hard
+        has:
+          strikebreak: 1
+          slide_jump: 1
   - name: Twilight Theatre - Back Of Auditorium
     code: 31
     region: Theatre Main
@@ -1112,15 +1458,26 @@ locations:
       - has: kick
       - has:
           cling: 2
+      - options:
+          difficulty: hard
+        has: slide_jump
   - name: Twilight Theatre - Center Stage
     code: 32
     region: Theatre Main
     rule:
-      has:
-        cutter: 1
-        cling: 6
-        plunge: 1
-        slide_jump: 1
+      or:
+      - has:
+          cutter: 1
+          cling: 6
+          plunge: 1
+          slide_jump: 1
+      - options:
+          difficulty: hard
+        has:
+          cutter: 1
+          cling: 6
+          kick_or_plunge: 1
+          slide_jump: 1
   - name: Twilight Theatre - Locked Door
     code: 33
     region: Theatre Main
@@ -1130,6 +1487,10 @@ locations:
       - or:
         - has: light
         - has: kick
+        - options:
+            difficulty: hard
+          has:
+            cling: 4
   - name: Twilight Theatre - Tucked Behind Boxes
     code: 34
     region: Theatre Main
@@ -1148,6 +1509,16 @@ locations:
           old_obscure: 1  # use crouch backflip
       - has:
           kick: 4
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
+          kick_or_plunge: 1
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
+          slide_jump: 1
 
   - name: Empty Bailey - Solar Wind
     code: 36
@@ -1162,6 +1533,11 @@ locations:
       - has: plunge
       - has:
           kick: 4
+      - options:
+          difficulty: hard
+        has:
+          kick: 2
+          breaker: 1
   - name: Empty Bailey - Cheese Bell
     code: 38
     region: Bailey Upper
@@ -1172,6 +1548,14 @@ locations:
       - has:
           cling: 2
           kick_or_plunge: 2
+      - options:
+          difficulty: hard
+        has:
+          kick: 3
+      - options:
+          difficulty: hard
+        has:
+          cling: 6
   - name: Empty Bailey - Guarded Hand
     code: 39
     region: Bailey Lower
@@ -1280,8 +1664,13 @@ locations:
     code: 49
     region: Tower Remains
     rule:
-      has:
-        kick_or_plunge: 2  # climb the right tower and cross
+      or:
+      - has:
+          kick_or_plunge: 2  # climb the right tower and cross
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
     can_create:
       split_cling_gem: false
   - name: Tower Remains - Atop The Tower
@@ -1419,24 +1808,39 @@ locations:
     code: 63
     region: Tower Remains
     rule:
-      has:
-        kick_or_plunge: 2
+      or:
+      - has:
+          kick_or_plunge: 2
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
     can_create:
       split_cling_gem: true
   - name: Tower Remains - Cling Gem 2
     code: 64
     region: Tower Remains
     rule:
-      has:
-        kick_or_plunge: 2
+      or:
+      - has:
+          kick_or_plunge: 2
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
     can_create:
       split_cling_gem: true
   - name: Tower Remains - Cling Gem 3
     code: 65
     region: Tower Remains
     rule:
-      has:
-        kick_or_plunge: 2
+      or:
+      - has:
+          kick_or_plunge: 2
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
     can_create:
       split_cling_gem: true
 

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -9,7 +9,7 @@ item_mapping:
   Slide: slide
   Solar Wind: slide_jump
   Sunsetter:
-    names: 
+    names:
       - plunge
       - kick_or_plunge
     first_only: true
@@ -273,6 +273,10 @@ regions:
             logic_level: hard
           has:
             kick_or_plunge: 2
+        - options:
+            logic_level: lunatic
+          ref: can_gold_ultra
+          has: plunge
     - region: Underbelly => Dungeon
   - name: Dungeon Escape Upper
     exits:
@@ -316,6 +320,9 @@ regions:
         - options:
             logic_level: expert
           has: slide
+        - options:
+            logic_level: lunatic
+          has: plunge
     - region: Castle Spiral Climb
       rule:
         or:
@@ -395,6 +402,10 @@ regions:
             logic_level: expert
           has:
             kick_or_plunge: 4
+        - options:
+            logic_level: lunatic
+          has:
+            kick: 3
   - name: Castle High Climb
 
   - name: Castle By Scythe Corridor
@@ -462,6 +473,11 @@ regions:
           has:
             slide: 1
             kick_or_plunge: 3
+        - options:
+            logic_level: lunatic
+          ref: can_gold_ultra
+          has:
+            kick_or_plunge: 2
   - name: Castle => Theatre (Front)
     exits:
     - region: Castle By Scythe Corridor
@@ -486,6 +502,9 @@ regions:
             logic_level: expert
           has:
             kick: 3
+        - options:
+            logic_level: lunatic
+          has: slide_jump
     - region: Castle Moon Room
       rule:
         or:
@@ -558,6 +577,13 @@ regions:
         - options:
             logic_level: expert
           has: slide
+        - options:
+            logic_level: lunatic
+          has: kick
+        - options:
+            logic_level: lunatic
+          has:
+            cling: 2
     - region: Castle Main
       rule:
         ref: can_attack
@@ -612,6 +638,12 @@ regions:
             logic_level: expert
           has:
             kick: 2
+        - options:
+            logic_level: lunatic
+          has:
+            light: 1
+            kick: 1
+            plunge: 1
   - name: Library Back
     exits:
     - region: Library Greaves
@@ -743,6 +775,25 @@ regions:
             breaker: 1
             slide: 1
             kick: 3
+        - options:
+            logic_level: lunatic
+          has:
+            breaker: 1
+            slide: 1
+            kick_or_plunge: 3
+        - options:
+            logic_level: lunatic
+          has:
+            breaker: 1
+            cling: 2
+        - options:
+            logic_level: lunatic
+          ref: can_gold_ultra
+          has:
+            light: 1
+            kick: 1
+            plunge: 1
+            cutter: 1
     - region: Keep => Underbelly
       rule:
         or:
@@ -818,6 +869,9 @@ regions:
         - options:
             logic_level: expert
           has: slide
+        - options:
+            logic_level: lunatic
+          has: light
     - region: Castle Main
     - region: Theatre Pillar => Bailey
   - name: Bailey Upper
@@ -869,6 +923,12 @@ regions:
             game_version: full_gold
             logic_level: expert
           has: slide
+        - options:
+            game_version: map_patch
+            logic_level: lunatic
+          has:
+            slide_jump: 1
+            pllunge: 1
 
   - name: Tower Remains
     exits:
@@ -900,6 +960,21 @@ regions:
           has:
             kick: 1
             plunge: 1
+        - options:
+            logic_level: lunatic
+          ref: can_gold_ultra
+          has: kick
+        - options:
+            logic_level: lunatic
+          has:
+            slide: 1
+            kick: 1
+            plunge: 1
+        - options:
+            logic_level: lunatic
+          has:
+            plunge: 1
+            kick: 2
   - name: Underbelly => Dungeon
     exits:
     - region: Dungeon Escape Lower
@@ -1098,6 +1173,9 @@ regions:
           has:
             kick: 1
             breaker: 1
+        - options:
+            logic_level: lunatic
+          has: kick
   - name: Underbelly Main Upper
     exits:
     - region: Underbelly Main Lower
@@ -1415,6 +1493,10 @@ regions:
           has:
             slide: 1
             kick_or_plunge: 3
+        - options:
+            logic_level: lunatic
+          has:
+            kick: 2
     - region: Theatre Pillar => Bailey
     - region: Castle => Theatre Pillar
   - name: Theatre Outside Scythe Corridor
@@ -1584,6 +1666,17 @@ locations:
         has:
           slide: 1
           kick: 1
+      - options:
+          logic_level: lunatic
+        has:
+          kick: 1
+          plunge: 1
+      - options:
+          logic_level: lunatic
+        has:
+          breaker: 1
+          plunge: 1
+          slide: 1
   - name: Dilapidated Dungeon - Rafters
     code: 6
     region: Dungeon Strong Eyes
@@ -1623,6 +1716,14 @@ locations:
         has:
           light: 1
           cling: 2
+      - options:
+          logic_level: lunatic
+        ref: can_gold_ultra
+      - options:
+          logic_level: lunatic
+        has:
+          slide: 1
+          plunge: 1
   - name: Dilapidated Dungeon - Strong Eyes
     code: 7
     region: Dungeon Strong Eyes
@@ -1665,6 +1766,12 @@ locations:
         has:
           slide: 1
           kick: 1
+      - options:
+          game_version: full_gold
+          logic_level: lunatic
+        has:
+          slide: 1
+          kick_or_plunge: 1
 
   - name: Castle Sansa - Indignation
     code: 8
@@ -1731,6 +1838,16 @@ locations:
         has:
           kick: 2
           slide: 1
+      - options:
+          logic_level: lunatic
+        ref: can_gold_slide_ultra
+        has: kick
+      - options:
+          logic_level: lunatic
+        has:
+          slide: 1
+          kick: 1
+          plunge: 1
   - name: Castle Sansa - Floater In Courtyard
     code: 12
     region: Castle Main
@@ -1784,6 +1901,11 @@ locations:
           logic_level: expert
         has:
           cling: 2
+      - options:
+          logic_level: lunatic
+        has:
+          slide: 1
+          kick: 1
 
   - name: Castle Sansa - Locked Door
     code: 13
@@ -1808,6 +1930,9 @@ locations:
       - options:
           logic_level: expert
         has: slide
+      - options:
+          logic_level: lunatic
+        has: light
   - name: Castle Sansa - Tall Room Near Wheel Crawlers
     code: 15
     region: Castle Main
@@ -1967,6 +2092,13 @@ locations:
           logic_level: expert
         has:
           cling: 4
+      - options:
+          logic_level: lunatic
+        has: slide
+      - options:
+          logic_level: lunatic
+        has:
+          cling: 2
 
   - name: Sansa Keep - Strikebreak
     code: 20
@@ -2001,7 +2133,10 @@ locations:
     code: 22
     region: Keep Main
     rule:
-      ref: can_attack
+      or:
+      - ref: can_attack
+      - options:
+          logic_level: lunatic
   - name: Sansa Keep - Lonely Throne
     code: 23
     region: Keep Throne Room
@@ -2033,20 +2168,24 @@ locations:
     code: 27
     region: Library Top
     rule:
-      ref: can_attack
       or:
-      - has:
-          cling: 2
-          kick_or_plunge: 1
-      - has:
-          kick_or_plunge: 2
+      - ref: can_attack
+        or:
+        - has:
+            cling: 2
+            kick_or_plunge: 1
+        - has:
+            kick_or_plunge: 2
+        - options:
+            logic_level: hard
+          has:
+            cling: 4
+        - options:
+            logic_level: expert
+            has: slide
       - options:
-          logic_level: hard
-        has:
-          cling: 4
-      - options:
-          logic_level: expert
-          has: slide
+          logic_level: lunatic
+        has: plunge
   - name: Listless Library - Locked Door Across
     code: 28
     region: Library Locked

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -1190,6 +1190,20 @@ locations:
           plunge: 1
         tags:
           old_obscure: 1
+      - options:
+          difficulty: hard
+        has:
+          cling: 6
+      - options:
+          difficulty: hard
+        has:
+          kick: 1
+          plunge: 1
+      - options:
+          difficulty: hard
+        has:
+          kick: 1
+          light: 1
   - name: Dilapidated Dungeon - Strong Eyes
     code: 7
     region: Dungeon Strong Eyes
@@ -1245,6 +1259,11 @@ locations:
       - has:
           slide_jump: 1
           kick_or_plunge: 2
+      - options:
+          difficulty: hard
+        has:
+          slide_jump: 1
+          kick: 1
   - name: Castle Sansa - Corner Corridor
     code: 11
     region: Castle Main
@@ -1254,6 +1273,10 @@ locations:
           cling: 2
       - has:
           kick: 4
+      - options:
+          difficulty: hard
+        has:
+          kick: 3
   - name: Castle Sansa - Floater In Courtyard
     code: 12
     region: Castle Main
@@ -1272,6 +1295,19 @@ locations:
           kick: 1
         tags:
           old_obscure: 1
+      - options:
+          difficulty: hard
+        has:
+          kick_or_plunge: 4
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
+          plunge: 1
+      - options:
+          difficulty: hard
+        has:
+          cling: 4
   - name: Castle Sansa - Locked Door
     code: 13
     region: Castle Main
@@ -1289,6 +1325,9 @@ locations:
           cling: 2
       - has:
           kick: 2
+      - options:
+          difficulty: hard
+        has: kick_or_plunge
   - name: Castle Sansa - Tall Room Near Wheel Crawlers
     code: 15
     region: Castle Main
@@ -1299,6 +1338,20 @@ locations:
           kick_or_plunge: 1
       - has:
           kick: 2
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
+      - options:
+          difficulty: hard
+        has: kick
+      - options:
+          difficulty: hard
+        tags:
+          old_obscure: 1
+        has:
+          slide_jump: 1
+          plunge: 1
   - name: Castle Sansa - Wheel Crawlers
     code: 16
     region: Castle Main
@@ -1315,6 +1368,14 @@ locations:
       - has: plunge
         tags:
           old_obscure: 1
+      - options:
+          difficulty: hard
+        has: kick
+      - options:
+          difficulty: hard
+        has:
+          slide_jump: 1
+          plunge: 1
   - name: Castle Sansa - High Climb From Courtyard
     code: 17
     region: Castle High Climb
@@ -1327,6 +1388,15 @@ locations:
           plunge: 1
       - has: kick
         ref: can_attack
+      - options:
+          difficulty: hard
+        has:
+          cling: 6
+      - options:
+          difficulty: hard
+        has:
+          plunge: 1
+          slide_jump: 1
   - name: Castle Sansa - Alcove Near Scythe Corridor
     code: 18
     region: Castle By Scythe Corridor
@@ -1338,6 +1408,20 @@ locations:
           plunge: 1
       - has:
           kick_or_plunge: 4
+      - options:
+          difficulty: hard
+        has:
+          cling: 4
+      - options:
+          difficulty: hard
+        has:
+          plunge: 1
+          cling: 2
+      - options:
+          difficulty: hard
+        has:
+          kick: 2
+          plunge: 1
   - name: Castle Sansa - Near Theatre Front
     code: 19
     region: Castle Moon Room
@@ -1348,6 +1432,15 @@ locations:
       - has:
           kick: 2
           plunge: 1
+      - options:
+          difficulty: hard
+        has:
+          cling: 6
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
+          kick: 2
 
   - name: Sansa Keep - Strikebreak
     code: 20
@@ -1366,6 +1459,9 @@ locations:
             kick: 1
         - has:
             kick: 3
+        - options:
+            difficulty: hard
+          has: kick
   - name: Sansa Keep - Alcove Near Locked Door
     code: 21
     region: Keep Locked Room
@@ -1409,6 +1505,11 @@ locations:
           kick_or_plunge: 1
       - has:
           kick_or_plunge: 2
+      - options:
+          difficulty: hard
+        ref: can_attack
+        has:
+          cling: 4
   - name: Listless Library - Locked Door Across
     code: 28
     region: Library Locked
@@ -1418,6 +1519,10 @@ locations:
           cling: 2
       - has: kick
       - has: slide_jump
+      - options:
+          difficulty: hard
+        has:
+          kick_or_plunge: 1
   - name: Listless Library - Locked Door Left
     code: 29
     region: Library Locked
@@ -1430,6 +1535,10 @@ locations:
           kick: 1
       - has:
           kick_or_plunge: 3
+      - options:
+          difficulty: hard
+        has:
+          kick: 2
 
   - name: Twilight Theatre - Soul Cutter
     code: 30
@@ -1598,6 +1707,15 @@ locations:
       - has:
           kick: 3
           slide_jump: 1
+      - options:
+          difficulty: hard
+        has:
+          kick: 3
+      - options:
+          difficulty: hard
+        has:
+          kick: 2
+          slide_jump: 1
   - name: The Underbelly - Building Near Little Guy
     code: 43
     region: Underbelly => Bailey
@@ -1606,6 +1724,10 @@ locations:
       - has: plunge
       - has:
           kick: 3
+      - options:
+          difficulty: hard
+        has:
+          kick: 2
   - name: The Underbelly - Locked Door
     code: 44
     region: Underbelly By Heliacal
@@ -1627,6 +1749,9 @@ locations:
             cling: 2
         - has:
             kick: 2
+      - options:
+          difficulty: hard
+        has: slide_jump
   - name: The Underbelly - Rafters Near Keep
     code: 46
     region: Underbelly => Keep
@@ -1636,29 +1761,53 @@ locations:
       - has:
           kick: 2
       - has: light
+      - options:
+          difficulty: hard
+        has: kick_or_plunge
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
   - name: The Underbelly - Strikebreak Wall
     code: 47
     region: Underbelly Main Upper
     rule:
-      has:
-        strikebreak: 1
-        light: 1
-        kick_or_plunge: 1
+      and:
+      - has:
+          strikebreak: 1
+      - or:
+        - has:
+            light: 1
+            kick_or_plunge: 1
+        - options:
+            difficulty: hard
+          has: light
+        - options:
+            difficulty: hard
+          has:
+            kick_or_plunge: 3
+
   - name: The Underbelly - Surrounded By Holes
     code: 48
     region: Underbelly Hole
     rule:
-      and:
-      - has:
-          cutter: 1
-          plunge: 1
-      - or:
-        - has: light
+      or:
+      - and:
         - has:
-            kick: 2
-        - has: kick
-          tags:
-            old_obscure: 1
+            cutter: 1
+            plunge: 1
+        - or:
+          - has: light
+          - has:
+              kick: 2
+          - has: kick
+            tags:
+              old_obscure: 1
+      - options:
+          difficulty: hard
+        has:
+          plunge: 1
+          cling: 6
 
   - name: Tower Remains - Cling Gem
     code: 49
@@ -1898,6 +2047,13 @@ locations:
           - has: slide_jump
           - tags:
               old_obscure: 1
+      - options:
+          difficulty: hard
+        has: kick
+      - options:
+          difficulty: hard
+        has:
+          cling: 2
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Trapped Goatling
@@ -1966,6 +2122,9 @@ locations:
           slide_jump: 1
       - has:
           cling: 2
+      - options:
+          difficulty: hard
+        has: kick
     can_create:
       randomize_goats: true
   - name: Empty Bailey - Alley Goatling
@@ -2074,6 +2233,11 @@ locations:
             light: 1
           tags:
             old_obscure: 1
+        - options:
+            difficulty: hard
+          tags:
+            old_obscure: 1
+          has: slide_jump
     can_create:
       randomize_chairs: true
 
@@ -2158,6 +2322,9 @@ locations:
       - has:
           cling: 2
       - has: light
+      - options:
+          difficulty: hard
+        has: slide_jump
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note in the Big Room
@@ -2171,6 +2338,15 @@ locations:
       - has:
           kick: 2
           slide_jump: 1
+      - options:
+          difficulty: hard
+        has:
+          kick_or_plunge: 2
+      - options:
+          difficulty: hard
+        has:
+          cling: 6
+          kick: 1
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note Behind a Locked Door

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -910,7 +910,7 @@ locations:
     rule:
       ref: can_unlock_door
     can_create:
-      game_version: FULL_GOLD
+      game_version: full_gold
   - name: Castle Sansa - Platform In Main Halls
     code: 14
     region: Castle Main
@@ -1148,7 +1148,7 @@ locations:
     rule:
       or:
       - and:
-        - can_reach: upper_bailey
+        - can_reach_region: upper_bailey
         - or:
           - has:
               cling: 2
@@ -1288,14 +1288,16 @@ locations:
         cling: 6
         slide_jump: 1
     can_create:
-      game_version: MAP_PATCH and options.randomize_time_trials
+      game_version: map_patch
+      randomize_time_trials: True
   - name: Castle Sansa - Time Trial
     code: 55
     region: Castle Main
     rule:
       ref: can_unlock_door
     can_create:
-      game_version: MAP_PATCH and options.randomize_time_trials
+      game_version: map_patch
+      randomize_time_trials: True
   - name: Sansa Keep - Time Trial
     code: 56
     region: Keep Throne Room
@@ -1308,7 +1310,8 @@ locations:
         slide_jump: 1
         bounce: 1
     can_create:
-      game_version: MAP_PATCH and options.randomize_time_trials
+      game_version: map_patch
+      randomize_time_trials: True
   - name: Listless Library - Time Trial
     code: 57
     region: Library Main
@@ -1318,7 +1321,8 @@ locations:
         plunge: 1
         kick: 3
     can_create:
-      game_version: MAP_PATCH and options.randomize_time_trials
+      game_version: map_patch
+      randomize_time_trials: True
   - name: Twilight Theatre - Time Trial
     code: 58
     region: Theatre Pillar
@@ -1330,7 +1334,8 @@ locations:
         cling: 6
         slide_jump: 1
     can_create:
-      game_version: MAP_PATCH and options.randomize_time_trials
+      game_version: map_patch
+      randomize_time_trials: True
   - name: Empty Bailey - Time Trial
     code: 59
     region: Bailey Upper
@@ -1342,7 +1347,8 @@ locations:
         cling: 6
         slide_jump: 1
     can_create:
-      game_version: MAP_PATCH and options.randomize_time_trials
+      game_version: map_patch
+      randomize_time_trials: True
   - name: The Underbelly - Time Trial
     code: 60
     region: Underbelly Main Upper
@@ -1354,7 +1360,8 @@ locations:
         cling: 6
         slide_jump: 1
     can_create:
-      game_version: MAP_PATCH and options.randomize_time_trials
+      game_version: map_patch
+      randomize_time_trials: True
   - name: Tower Remains - Time Trial
     code: 61
     region: The Great Door
@@ -1366,13 +1373,14 @@ locations:
         cling: 6
         slide_jump: 1
     can_create:
-      game_version: MAP_PATCH and options.randomize_time_trials
+      game_version: map_patch
+      randomize_time_trials: True
 
   - name: Castle Sansa - Memento
     code: 62
     region: Castle Main
     can_create:
-      game_version: MAP_PATCH
+      game_version: map_patch
 
   - name: Tower Remains - Cling Gem 1
     code: 63
@@ -1465,12 +1473,14 @@ locations:
     code: 75
     region: Castle Main
     can_create:
-      randomize_goats and options.game_version: MAP_PATCH
+      randomize_goats: True
+      game_version: map_patch
   - name: Castle Sansa - Goatling Near Library
     code: 76
     region: Castle Main
     can_create:
-      randomize_goats and options.game_version: MAP_PATCH
+      randomize_goats: True
+      game_version: map_patch
   - name: Sansa Keep - Furniture-less Goatling
     code: 77
     region: Keep Main

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -105,264 +105,257 @@ ref_rules:
 regions:
   - name: Dungeon Mirror
     exits:
-      - region: Dungeon Slide
-        rule:
-          ref: can_attack
+    - region: Dungeon Slide
+      rule:
+        ref: can_attack
   - name: Dungeon Slide
     exits:
-      - region: Dungeon Mirror
-        rule:
-          ref: can_attack
-      - region: Dungeon Strong Eyes
-        rule:
-          has: slide
-      - region: Dungeon Escape Lower
-        rule:
-          or:
-            - and:
-              - ref: can_attack
-              - ref: can_enter_dark_rooms
-            - has: breaker
-              tags:
-                dungeon_escape: 1
+    - region: Dungeon Mirror
+      rule:
+        ref: can_attack
+    - region: Dungeon Strong Eyes
+      rule:
+        has: slide
+    - region: Dungeon Escape Lower
+      rule:
+        or:
+        - and:
+          - ref: can_attack
+          - ref: can_enter_dark_rooms
+        - has: breaker
+          tags:
+            dungeon_escape: 1
   - name: Dungeon Strong Eyes
     exits:
-      - region: Dungeon Slide
-        rule:
-          has: slide
-      - region: Dungeon => Castle
-  - name: Dungeon => Castle  # Dungeon Top Exit
+    - region: Dungeon Slide
+      rule:
+        has: slide
+    - region: Dungeon => Castle
+  - name: Dungeon => Castle
     exits:
-      - region: Dungeon Mirror
-      - region: Dungeon Strong Eyes
-        rule:
-          # TODO convert to or rule and update to include shortcut
-          ref: can_unlock_door
-      - region: Castle Main
-        entrance_name: Dungeon Top Exit
+    - region: Dungeon Mirror
+    - region: Dungeon Strong Eyes
+      rule:
+        ref: can_unlock_door
+    - region: Castle Main
+      entrance_name: Dungeon Top Exit
   - name: Dungeon Escape Lower
     exits:
-      - region: Dungeon Slide
-        rule:
-      - region: Dungeon Escape Upper
-        rule:
-      - region: Underbelly => Dungeon
+    - region: Dungeon Slide
+      rule: null
+    - region: Dungeon Escape Upper
+      rule: null
+    - region: Underbelly => Dungeon
   - name: Dungeon Escape Upper
     exits:
-      - region: Dungeon Escape Lower
-        rule:
-      - region: Theatre Outside Scythe Corridor
-        rule:
-
+    - region: Dungeon Escape Lower
+      rule: null
+    - region: Theatre Outside Scythe Corridor
+      rule: null
   - name: Castle Main
     exits:
-      - region: Dungeon => Castle
-      - region: Keep Main
-      - region: Bailey Lower
-      - region: Library Main
-        rule:
-      - region: Castle => Theatre Pillar
-        rule:
-      - region: Castle Spiral Climb
-        rule:
-      - region: Keep (Northeast) => Castle
-        rule:
+    - region: Dungeon => Castle
+    - region: Keep Main
+    - region: Bailey Lower
+    - region: Library Main
+      rule: null
+    - region: Castle => Theatre Pillar
+      rule: null
+    - region: Castle Spiral Climb
+      rule: null
+    - region: Keep (Northeast) => Castle
+      rule: null
   - name: Castle Spiral Climb
     exits:
-      - region: Castle Main
-      - region: Castle High Climb
-        rule:
-      - region: Castle By Scythe Corridor
-        rule:
+    - region: Castle Main
+    - region: Castle High Climb
+      rule: null
+    - region: Castle By Scythe Corridor
+      rule: null
   - name: Castle High Climb
 
   - name: Castle By Scythe Corridor
     exits:
-      - region: Castle Spiral Climb
-        rule:
-      - region: Castle High Climb
-        rule:
-      - region: Castle => Theatre (Front)
-        rule:
+    - region: Castle Spiral Climb
+      rule: null
+    - region: Castle High Climb
+      rule: null
+    - region: Castle => Theatre (Front)
+      rule: null
   - name: Castle => Theatre (Front)
     exits:
-      - region: Castle By Scythe Corridor
-        rule:
-      - region: Castle Moon Room
-        rule:
-      - region: Theatre Main
-        rule:
+    - region: Castle By Scythe Corridor
+      rule: null
+    - region: Castle Moon Room
+      rule: null
+    - region: Theatre Main
+      rule: null
   - name: Castle Moon Room
 
 
   - name: Library Main
     exits:
-      - region: Library Locked
-        rule:
-      - region: Library Greaves
-        rule:
-      - region: Library Top
-        rule:
-      - region: Castle Main
-        rule:
+    - region: Library Locked
+      rule: null
+    - region: Library Greaves
+      rule: null
+    - region: Library Top
+      rule: null
+    - region: Castle Main
+      rule: null
   - name: Library Locked
 
   - name: Library Greaves
     exits:
-      - region: Library Back
-        rule:
+    - region: Library Back
+      rule: null
   - name: Library Top
     exits:
-      - region: Library Back
-        rule:
+    - region: Library Back
+      rule: null
   - name: Library Back
     exits:
-      - region: Library Greaves
-        rule:
-      - region: Library Top
-        rule:
-
+    - region: Library Greaves
+      rule: null
+    - region: Library Top
+      rule: null
   - name: Keep Main
     exits:
-      - region: Keep Locked Room
-        rule:
-      - region: Keep Sunsetter
-        rule:
-      - region: Keep Throne Room
-        rule:
-      - region: Keep => Underbelly
-        rule:
-      - region: Theatre Outside Scythe Corridor
-        rule:
-      - region: Keep (Northeast) => Castle
-        rule:
-      - region: Castle Main
-        rule:
+    - region: Keep Locked Room
+      rule: null
+    - region: Keep Sunsetter
+      rule: null
+    - region: Keep Throne Room
+      rule: null
+    - region: Keep => Underbelly
+      rule: null
+    - region: Theatre Outside Scythe Corridor
+      rule: null
+    - region: Keep (Northeast) => Castle
+      rule: null
+    - region: Castle Main
+      rule: null
   - name: Keep Locked Room
     exits:
-      - region: Keep Sunsetter
+    - region: Keep Sunsetter
   - name: Keep Sunsetter
 
   - name: Keep Throne Room
 
   - name: Keep => Underbelly
     exits:
-      - region: Keep Main
-      - region: Underbelly => Keep
+    - region: Keep Main
+    - region: Underbelly => Keep
   - name: Keep (Northeast) => Castle
     exits:
-      - region: Keep Main
-      - region: Castle Main
-
+    - region: Keep Main
+    - region: Castle Main
   - name: Bailey Lower
     exits:
-      - region: Bailey Upper
-        rule:
-      - region: Castle Main
-      - region: Theatre Pillar => Bailey
+    - region: Bailey Upper
+      rule: null
+    - region: Castle Main
+    - region: Theatre Pillar => Bailey
   - name: Bailey Upper
     exits:
-      - region: Bailey Lower
-        rule:
-      - region: Underbelly => Bailey
-        rule:
-      - region: Tower Remains
-        rule:
+    - region: Bailey Lower
+      rule: null
+    - region: Underbelly => Bailey
+      rule: null
+    - region: Tower Remains
+      rule: null
   - name: Tower Remains
     exits:
-      - region: The Great Door
-        rule:
-
+    - region: The Great Door
+      rule: null
   - name: Underbelly => Dungeon
     exits:
-      - region: Dungeon Escape Lower
-        rule:
-      - region: Underbelly Light Pillar
-      - region: Underbelly Ascendant Light
-        rule:
+    - region: Dungeon Escape Lower
+      rule: null
+    - region: Underbelly Light Pillar
+    - region: Underbelly Ascendant Light
+      rule: null
   - name: Underbelly Light Pillar
     exits:
-      - region: Underbelly Main Upper
-      - region: Underbelly => Dungeon
-        rule:
-      - region: Underbelly Ascendant Light
-        rule:
+    - region: Underbelly Main Upper
+    - region: Underbelly => Dungeon
+      rule: null
+    - region: Underbelly Ascendant Light
+      rule: null
   - name: Underbelly Ascendant Light
     exits:
-      - region: Underbelly => Dungeon
-        rule:
+    - region: Underbelly => Dungeon
+      rule: null
   - name: Underbelly Main Lower
     exits:
-      - region: Underbelly => Bailey
-      - region: Underbelly Hole
-        rule:
-      - region: Underbelly By Heliacal
-        rule:
-      - region: Underbelly Main Upper
-        rule:
+    - region: Underbelly => Bailey
+    - region: Underbelly Hole
+      rule: null
+    - region: Underbelly By Heliacal
+      rule: null
+    - region: Underbelly Main Upper
+      rule: null
   - name: Underbelly Main Upper
     exits:
-      - region: Underbelly Main Lower
-      - region: Underbelly Light Pillar
-        rule:
-      - region: Underbelly By Heliacal
-        rule:
+    - region: Underbelly Main Lower
+    - region: Underbelly Light Pillar
+      rule: null
+    - region: Underbelly By Heliacal
+      rule: null
   - name: Underbelly By Heliacal
     exits:
-      - region: Underbelly Main Upper
-        rule:
+    - region: Underbelly Main Upper
+      rule: null
   - name: Underbelly => Bailey
     exits:
-      - region: Bailey Upper
-        rule:
-      - region: Bailey Lower
-      - region: Underbelly Main Lower
-        rule:
+    - region: Bailey Upper
+      rule: null
+    - region: Bailey Lower
+    - region: Underbelly Main Lower
+      rule: null
   - name: Underbelly => Keep
     exits:
-      - region: Keep => Underbelly
-      - region: Underbelly Hole
-        rule:
+    - region: Keep => Underbelly
+    - region: Underbelly Hole
+      rule: null
   - name: Underbelly Hole
     exits:
-      - region: Underbelly Main Lower
-        rule:
-      - region: Underbelly => Keep
-        rule:
-
+    - region: Underbelly Main Lower
+      rule: null
+    - region: Underbelly => Keep
+      rule: null
   - name: Theatre Main
     exits:
-      - region: Theatre Outside Scythe Corridor
-        rule:
-      - region: Theatre Pillar
-        rule:
-      - region: Castle => Theatre (Front)
-        rule:
+    - region: Theatre Outside Scythe Corridor
+      rule: null
+    - region: Theatre Pillar
+      rule: null
+    - region: Castle => Theatre (Front)
+      rule: null
   - name: Theatre Pillar => Bailey
     exits:
-      - region: Theatre Pillar
-        rule:
-      - region: Bailey Lower
+    - region: Theatre Pillar
+      rule: null
+    - region: Bailey Lower
   - name: Castle => Theatre Pillar
     exits:
-      - region: Theatre Pillar
-        rule:
-      - region: Castle Main
+    - region: Theatre Pillar
+      rule: null
+    - region: Castle Main
   - name: Theatre Pillar
     exits:
-      - region: Theatre Main
-        rule:
-      - region: Theatre Pillar => Bailey
-      - region: Castle => Theatre Pillar
+    - region: Theatre Main
+      rule: null
+    - region: Theatre Pillar => Bailey
+    - region: Castle => Theatre Pillar
   - name: Theatre Outside Scythe Corridor
     exits:
-      - region: Theatre Main
-        rule:
-      - region: Dungeon Escape Upper
-        rule:
-      - region: Keep Main
-        rule:
-
+    - region: Theatre Main
+      rule: null
+    - region: Dungeon Escape Upper
+      rule: null
+    - region: Keep Main
+      rule: null
   - name: The Great Door
 
 
@@ -392,275 +385,483 @@ locations:
   - name: Dilapidated Dungeon - Dream Breaker
     code: 1
     region: Dungeon Mirror
-    rule:
-    
   - name: Dilapidated Dungeon - Slide
     code: 2
     region: Dungeon Slide
-    rule:
-    
   - name: Dilapidated Dungeon - Alcove Near Mirror
     code: 3
     region: Dungeon => Castle
-    rule:
-    
   - name: Dilapidated Dungeon - Dark Orbs
     code: 4
     region: Dungeon Escape Upper
     rule:
-    
+      or:
+      - has:
+          cling: 2
+          bounce: 1
+      - has:
+          cling: 2
+          kick_or_plunge: 3
+      - has:
+          kick: 2
+          bounce: 1
+      - has:
+          slide_jump: 1
+          kick: 1
+          bounce: 1
   - name: Dilapidated Dungeon - Past Poles
     code: 5
     region: Dungeon Strong Eyes
     rule:
-    
+      or:
+      - has:
+          cling: 2
+          kick_or_plunge: 1
+      - has:
+          kick: 3
+      - has:
+          slide_jump: 1
+          kick: 2
+          tags: obscure
   - name: Dilapidated Dungeon - Rafters
     code: 6
     region: Dungeon Strong Eyes
     rule:
-    
+      or:
+      - has:
+          kick_or_plunge: 3
+      - has:
+          bounce: 1
+          plunge: 1
+          tags: obscure
   - name: Dilapidated Dungeon - Strong Eyes
     code: 7
     region: Dungeon Strong Eyes
-    rule:
-    
+    rule: null
 
   - name: Castle Sansa - Indignation
     code: 8
     region: Castle Main
-    rule:
-    
+    rule: null
   - name: Castle Sansa - Alcove Near Dungeon
     code: 9
     region: Castle => Theatre Pillar
     rule:
-    
+      or:
+      - has:
+          cling: 2
+      - has: kick
+      - has: slide_jump
+      - has: plunge
+        tags: obscure
   - name: Castle Sansa - Balcony
     code: 10
     region: Castle Main
     rule:
-    
+      or:
+      - has:
+          cling: 2
+      - has:
+          kick_or_plunge: 3
+      - has:
+          slide_jump: 1
+          kick_or_plunge: 2
   - name: Castle Sansa - Corner Corridor
     code: 11
     region: Castle Main
     rule:
-    
+      or:
+      - has:
+          cling: 2
+      - has:
+          kick: 4
   - name: Castle Sansa - Floater In Courtyard
     code: 12
     region: Castle Main
     rule:
-    
+      or:
+      - has:
+          bounce: 1
+          plunge: 1
+      - has:
+          bounce: 1
+          kick: 2
+      - has:
+          kick: 4
+      - has:
+          bounce: 1
+          kick: 1
+          tags: obscure
   - name: Castle Sansa - Locked Door
     code: 13
     region: Castle Main
     rule:
+      ref: can_unlock_door
     can_create:
       game_version: FULL_GOLD
   - name: Castle Sansa - Platform In Main Halls
     code: 14
     region: Castle Main
     rule:
-    
+      or:
+      - has: plunge
+      - has:
+          cling: 2
+      - has:
+          kick: 2
   - name: Castle Sansa - Tall Room Near Wheel Crawlers
     code: 15
     region: Castle Main
     rule:
-    
+      or:
+      - has:
+          cling: 2
+          kick_or_plunge: 1
+      - has:
+          kick: 2
   - name: Castle Sansa - Wheel Crawlers
     code: 16
     region: Castle Main
     rule:
-    
+      or:
+      - has: bounce
+      - has:
+          cling: 2
+      - has:
+          kick: 2
+      - has:
+          kick: 1
+          slide_jump: 1
+      - has: plunge
+        tags: obscure
   - name: Castle Sansa - High Climb From Courtyard
     code: 17
     region: Castle High Climb
     rule:
-    
+      or:
+      - has:
+          kick: 2
+      - has:
+          cling: 2
+          plunge: 1
+      - has: kick
+        ref: can_attack
   - name: Castle Sansa - Alcove Near Scythe Corridor
     code: 18
     region: Castle By Scythe Corridor
     rule:
-    
+      or:
+      - has:
+          cling: 2
+          kick: 1
+          plunge: 1
+      - has:
+          kick_or_plunge: 4
   - name: Castle Sansa - Near Theatre Front
     code: 19
     region: Castle Moon Room
     rule:
-    
+      or:
+      - has:
+          kick: 4
+      - has:
+          kick: 2
+          plunge: 1
 
   - name: Sansa Keep - Strikebreak
     code: 20
     region: Keep Main
     rule:
-    
+      and:
+      - has: breaker
+      - or:
+        - has: slide
+        - has: strikebreak
+      - or:
+        - has:
+            cling: 2
+        - has:
+            plunge: 1
+            kick: 1
+        - has:
+            kick: 3
   - name: Sansa Keep - Alcove Near Locked Door
     code: 21
     region: Keep Locked Room
-    
   - name: Sansa Keep - Levers Room
     code: 22
     region: Keep Main
     rule:
-    
+      ref: can_attack
   - name: Sansa Keep - Lonely Throne
     code: 23
     region: Keep Throne Room
-    
   - name: Sansa Keep - Near Theatre
     code: 24
     region: Keep Main
     rule:
-    
+      or:
+      - has: kick_or_plunge
+      - has:
+          cling: 2
   - name: Sansa Keep - Sunsetter
     code: 25
     region: Keep Sunsetter
     rule:
-    
+      ref: can_attack
 
   - name: Listless Library - Sun Greaves
     code: 26
     region: Library Greaves
     rule:
+      ref: can_attack
     can_create:
       split_sun_greaves: false
   - name: Listless Library - Upper Back
     code: 27
     region: Library Top
     rule:
-    
+      ref: can_attack
+      or:
+      - has:
+          cling: 2
+          kick_or_plunge: 1
+      - has:
+          kick_or_plunge: 2
   - name: Listless Library - Locked Door Across
     code: 28
     region: Library Locked
     rule:
-    
+      or:
+      - has:
+          cling: 2
+      - has: kick
+      - has: slide_jump
   - name: Listless Library - Locked Door Left
     code: 29
     region: Library Locked
     rule:
-    
+      or:
+      - has:
+          cling: 2
+      - has:
+          slide_jump: 1
+          kick: 1
+      - has:
+          kick_or_plunge: 3
 
   - name: Twilight Theatre - Soul Cutter
     code: 30
     region: Theatre Main
     rule:
-    
+      and:
+      - has: strikebreak
+      - or:
+        - has: bounce
+        - has: kick_or_plunge
+        - has:
+            cling: 2
   - name: Twilight Theatre - Back Of Auditorium
     code: 31
     region: Theatre Main
     rule:
-    
+      or:
+      - has: plunge
+        tags: obscure
+      - has: kick
+      - has:
+          cling: 2
   - name: Twilight Theatre - Center Stage
     code: 32
     region: Theatre Main
     rule:
-    
+      has:
+        cutter: 1
+        cling: 6
+        plunge: 1
+        slide_jump: 1
   - name: Twilight Theatre - Locked Door
     code: 33
     region: Theatre Main
     rule:
-    
+      and:
+      - ref: can_unlock_door
+      - or:
+        - has: bounce
+        - has: kick
   - name: Twilight Theatre - Tucked Behind Boxes
     code: 34
     region: Theatre Main
-    
   - name: Twilight Theatre - Corner Beam
     code: 35
     region: Theatre Pillar
     rule:
-    
+      or:
+      - has:
+          cling: 2
+          kick_or_plunge: 2
+      - has:
+          plunge: 1
+          kick: 3
+          tags: obscure
+      - has:
+          kick: 4
 
   - name: Empty Bailey - Solar Wind
     code: 36
     region: Bailey Lower
     rule:
-    
+      has: slide
   - name: Empty Bailey - Center Steeple
     code: 37
     region: Bailey Upper
     rule:
-    
+      or:
+      - has: plunge
+      - has:
+          kick: 4
   - name: Empty Bailey - Cheese Bell
     code: 38
     region: Bailey Upper
     rule:
-    
+      or:
+      - has:
+          kick: 4
+      - has:
+          cling: 2
+          kick_or_plunge: 2
   - name: Empty Bailey - Guarded Hand
     code: 39
     region: Bailey Lower
     rule:
-    
+      or:
+      - and:
+        - can_reach: upper_bailey
+        - or:
+          - has:
+              cling: 2
+          - has:
+              kick: 3
+          - tag: obscure_tech
+      - and:
+        - has: breaker
+        - or:
+          - has: plunge
+          - has:
+              kick: 2
   - name: Empty Bailey - Inside Building
     code: 40
     region: Bailey Lower
     rule:
-    
+      has: slide
 
   - name: The Underbelly - Ascendant Light
     code: 41
     region: Underbelly Ascendant Light
-    
   - name: The Underbelly - Alcove Near Light
     code: 42
     region: Underbelly Light Pillar
     rule:
-    
+      or:
+      - ref: can_attack
+      - has:
+          cling: 2
+      - has:
+          kick: 4
+      - has:
+          kick: 3
+          slide_jump: 1
   - name: The Underbelly - Building Near Little Guy
     code: 43
     region: Underbelly => Bailey
     rule:
-    
+      or:
+      - has: plunge
+      - has:
+          kick: 3
   - name: The Underbelly - Locked Door
     code: 44
     region: Underbelly By Heliacal
     rule:
-    
+      ref: can_unlock_door
   - name: The Underbelly - Main Room
     code: 45
     region: Underbelly Main Upper
     rule:
-    
+      or:
+      - has: plunge
+      - has:
+          slide_jump: 1
+          kick: 1
+      - tag: obscure_tech
+        or:
+        - has:
+            cling: 2
+        - has:
+            kick: 2
   - name: The Underbelly - Rafters Near Keep
     code: 46
     region: Underbelly => Keep
     rule:
-    
+      or:
+      - has: plunge
+      - has:
+          kick: 2
+      - has: bounce
   - name: The Underbelly - Strikebreak Wall
     code: 47
     region: Underbelly Main Upper
     rule:
-    
+      has:
+        strikebreak: 1
+        bounce: 1
+        kick_or_plunge: 1
   - name: The Underbelly - Surrounded By Holes
     code: 48
     region: Underbelly Hole
     rule:
-    
+      and:
+      - has:
+          cutter: 1
+          plunge: 1
+      - or:
+        - has: bounce
+        - has:
+            kick: 2
+        - has: kick
+          tag: obscure_tech
 
   - name: Tower Remains - Cling Gem
     code: 49
     region: Tower Remains
     rule:
+      has:
+        kick_or_plunge: 2
     can_create:
       split_cling_gem: false
   - name: Tower Remains - Atop The Tower
     code: 50
     region: The Great Door
-    
 
   - name: Listless Library - Sun Greaves 1
     code: 51
     region: Library Greaves
     rule:
+      ref: can_attack
     can_create:
       split_sun_greaves: true
   - name: Listless Library - Sun Greaves 2
     code: 52
     region: Library Greaves
     rule:
+      ref: can_attack
     can_create:
       split_sun_greaves: true
   - name: Listless Library - Sun Greaves 3
     code: 53
     region: Library Greaves
     rule:
+      ref: can_attack
     can_create:
       split_sun_greaves: true
 
@@ -668,48 +869,90 @@ locations:
     code: 54
     region: Dungeon Mirror
     rule:
+      has:
+        breaker: 1
+        plunge: 1
+        kick: 3
+        cling: 6
+        slide_jump: 1
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Castle Sansa - Time Trial
     code: 55
     region: Castle Main
     rule:
+      ref: can_unlock_door
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Sansa Keep - Time Trial
     code: 56
     region: Keep Throne Room
     rule:
+      has:
+        breaker: 1
+        plunge: 1
+        kick: 3
+        cling: 6
+        slide_jump: 1
+        bounce: 1
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Listless Library - Time Trial
     code: 57
     region: Library Main
     rule:
+      has:
+        breaker: 1
+        plunge: 1
+        kick: 3
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Twilight Theatre - Time Trial
     code: 58
     region: Theatre Pillar
     rule:
+      has:
+        breaker: 1
+        plunge: 1
+        kick: 3
+        cling: 6
+        slide_jump: 1
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Empty Bailey - Time Trial
     code: 59
     region: Bailey Upper
     rule:
+      has:
+        breaker: 1
+        plunge: 1
+        kick: 3
+        cling: 6
+        slide_jump: 1
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: The Underbelly - Time Trial
     code: 60
     region: Underbelly Main Upper
     rule:
+      has:
+        breaker: 1
+        plunge: 1
+        kick: 3
+        cling: 6
+        slide_jump: 1
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
   - name: Tower Remains - Time Trial
     code: 61
     region: The Great Door
     rule:
+      has:
+        breaker: 1
+        plunge: 1
+        kick: 3
+        cling: 6
+        slide_jump: 1
     can_create:
       game_version: MAP_PATCH and options.randomize_time_trials
 
@@ -723,18 +966,24 @@ locations:
     code: 63
     region: Tower Remains
     rule:
+      has:
+        kick_or_plunge: 2
     can_create:
       split_cling_gem: true
   - name: Tower Remains - Cling Gem 2
     code: 64
     region: Tower Remains
     rule:
+      has:
+        kick_or_plunge: 2
     can_create:
       split_cling_gem: true
   - name: Tower Remains - Cling Gem 3
     code: 65
     region: Tower Remains
     rule:
+      has:
+        kick_or_plunge: 2
     can_create:
       split_cling_gem: true
 
@@ -747,6 +996,7 @@ locations:
     code: 67
     region: Dungeon Mirror
     rule:
+      ref: can_attack
     can_create:
       randomize_goats: true
   - name: Dilapidated Dungeon - Unwelcoming Goatling
@@ -778,12 +1028,25 @@ locations:
     code: 73
     region: Castle Main
     rule:
+      or:
+      - has:
+          kick: 2
+      - and:
+        - has: plunge
+        - or:
+          - has:
+              cling: 2
+          - has: kick
+          - has: bounce
+          - has: slide_jump
+          - tags: obscure
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Trapped Goatling
     code: 74
     region: Castle By Scythe Corridor
     rule:
+      ref: can_attack
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Memento Goatling
@@ -830,12 +1093,25 @@ locations:
     code: 83
     region: Theatre Main
     rule:
+      or:
+      - has:
+          kick: 2
+      - has:
+          kick: 1
+          plunge: 1
+          tags: obscure
+      - has:
+          kick: 1
+          slide_jump: 1
+      - has:
+          cling: 2
     can_create:
       randomize_goats: true
   - name: Empty Bailey - Alley Goatling
     code: 84
     region: Bailey Lower
     rule:
+      has: slide
     can_create:
       randomize_goats: true
 
@@ -912,13 +1188,29 @@ locations:
   - name: Twilight Theatre - Stage Left Stool
     code: 99
     region: Theatre Main
-    rule:
+    rule: # TODO: logic  could be filled out, for now it's fine
+      has:
+        cling: 4
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stage Right Stool
     code: 100
     region: Theatre Main
-    rule:
+    rule: # TODO: logic  could be filled out, for now it's fine
+      and:
+      - has: cutter
+      - or:
+        - has: kick
+        - has:
+            cling: 2
+        - has:
+            slide_jump: 1
+            plunge: 1
+            tags: obscure
+        - has:
+            slide_jump: 1
+            bounce: 1
+            tags: obscure
     can_create:
       randomize_chairs: true
 
@@ -996,19 +1288,33 @@ locations:
   - name: The Underbelly - Note on a Ledge
     code: 115
     region: Underbelly => Bailey
-    rule:
+    rule: # TODO: logic  could be filled out, for now it's fine
+      or:
+      - has: kick
+      - has: plunge
+      - has:
+          cling: 2
+      - has: bounce
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note in the Big Room
     code: 116
     region: Underbelly Main Lower
-    rule:
+    rule: # TODO: logic  could be filled out, for now it's fine
+      or:
+      - has:
+          kick: 4
+          plunge: 1
+      - has:
+          kick: 2
+          slide_jump: 1
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note Behind a Locked Door
     code: 117
     region: Underbelly By Heliacal
     rule:
+      ref: can_unlock_door
     can_create:
       randomize_notes: true
 

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -147,7 +147,6 @@ regions:
       - region: Dungeon Escape Upper
         rule:
       - region: Underbelly => Dungeon
-        rule:
   - name: Dungeon Escape Upper
     exits:
       - region: Dungeon Escape Lower
@@ -158,11 +157,8 @@ regions:
   - name: Castle Main
     exits:
       - region: Dungeon => Castle
-        rule:
       - region: Keep Main
-        rule:
       - region: Bailey Lower
-        rule:
       - region: Library Main
         rule:
       - region: Castle => Theatre Pillar
@@ -174,7 +170,6 @@ regions:
   - name: Castle Spiral Climb
     exits:
       - region: Castle Main
-        rule:
       - region: Castle High Climb
         rule:
       - region: Castle By Scythe Corridor
@@ -246,7 +241,6 @@ regions:
   - name: Keep Locked Room
     exits:
       - region: Keep Sunsetter
-        rule:
   - name: Keep Sunsetter
 
   - name: Keep Throne Room
@@ -254,24 +248,18 @@ regions:
   - name: Keep => Underbelly
     exits:
       - region: Keep Main
-        rule:
       - region: Underbelly => Keep
-        rule:
   - name: Keep (Northeast) => Castle
     exits:
       - region: Keep Main
-        rule:
       - region: Castle Main
-        rule:
 
   - name: Bailey Lower
     exits:
       - region: Bailey Upper
         rule:
       - region: Castle Main
-        rule:
       - region: Theatre Pillar => Bailey
-        rule:
   - name: Bailey Upper
     exits:
       - region: Bailey Lower
@@ -290,13 +278,11 @@ regions:
       - region: Dungeon Escape Lower
         rule:
       - region: Underbelly Light Pillar
-        rule:
       - region: Underbelly Ascendant Light
         rule:
   - name: Underbelly Light Pillar
     exits:
       - region: Underbelly Main Upper
-        rule:
       - region: Underbelly => Dungeon
         rule:
       - region: Underbelly Ascendant Light
@@ -308,7 +294,6 @@ regions:
   - name: Underbelly Main Lower
     exits:
       - region: Underbelly => Bailey
-        rule:
       - region: Underbelly Hole
         rule:
       - region: Underbelly By Heliacal
@@ -318,7 +303,6 @@ regions:
   - name: Underbelly Main Upper
     exits:
       - region: Underbelly Main Lower
-        rule:
       - region: Underbelly Light Pillar
         rule:
       - region: Underbelly By Heliacal
@@ -332,13 +316,11 @@ regions:
       - region: Bailey Upper
         rule:
       - region: Bailey Lower
-        rule:
       - region: Underbelly Main Lower
         rule:
   - name: Underbelly => Keep
     exits:
       - region: Keep => Underbelly
-        rule:
       - region: Underbelly Hole
         rule:
   - name: Underbelly Hole
@@ -361,21 +343,17 @@ regions:
       - region: Theatre Pillar
         rule:
       - region: Bailey Lower
-        rule:
   - name: Castle => Theatre Pillar
     exits:
       - region: Theatre Pillar
         rule:
       - region: Castle Main
-        rule:
   - name: Theatre Pillar
     exits:
       - region: Theatre Main
         rule:
       - region: Theatre Pillar => Bailey
-        rule:
       - region: Castle => Theatre Pillar
-        rule:
   - name: Theatre Outside Scythe Corridor
     exits:
       - region: Theatre Main
@@ -517,7 +495,6 @@ locations:
   - name: Sansa Keep - Alcove Near Locked Door
     code: 21
     region: Keep Locked Room
-    rule:
     
   - name: Sansa Keep - Levers Room
     code: 22
@@ -527,7 +504,6 @@ locations:
   - name: Sansa Keep - Lonely Throne
     code: 23
     region: Keep Throne Room
-    rule:
     
   - name: Sansa Keep - Near Theatre
     code: 24
@@ -585,7 +561,6 @@ locations:
   - name: Twilight Theatre - Tucked Behind Boxes
     code: 34
     region: Theatre Main
-    rule:
     
   - name: Twilight Theatre - Corner Beam
     code: 35
@@ -622,7 +597,6 @@ locations:
   - name: The Underbelly - Ascendant Light
     code: 41
     region: Underbelly Ascendant Light
-    rule:
     
   - name: The Underbelly - Alcove Near Light
     code: 42
@@ -669,7 +643,6 @@ locations:
   - name: Tower Remains - Atop The Tower
     code: 50
     region: The Great Door
-    rule:
     
 
   - name: Listless Library - Sun Greaves 1
@@ -743,7 +716,6 @@ locations:
   - name: Castle Sansa - Memento
     code: 62
     region: Castle Main
-    rule:
     can_create:
       game_version: MAP_PATCH
 
@@ -769,7 +741,6 @@ locations:
   - name: Dilapidated Dungeon - Mirror Room Goatling
     code: 66
     region: Dungeon Mirror
-    rule:
     can_create:
       randomize_goats: true
   - name: Dilapidated Dungeon - Rambling Goatling
@@ -781,31 +752,26 @@ locations:
   - name: Dilapidated Dungeon - Unwelcoming Goatling
     code: 68
     region: Dungeon Strong Eyes
-    rule:
     can_create:
       randomize_goats: true
   - name: Dilapidated Dungeon - Repentant Goatling
     code: 69
     region: Dungeon Strong Eyes
-    rule:
     can_create:
       randomize_goats: true
   - name: Dilapidated Dungeon - Defeatist Goatling
     code: 70
     region: Dungeon Strong Eyes
-    rule:
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Crystal Licker Goatling
     code: 71
     region: Castle Main
-    rule:
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Gazebo Goatling
     code: 72
     region: Castle Main
-    rule:
     can_create:
       randomize_goats: true
   - name: Castle Sansa - Bubblephobic Goatling
@@ -823,49 +789,41 @@ locations:
   - name: Castle Sansa - Memento Goatling
     code: 75
     region: Castle Main
-    rule:
     can_create:
       randomize_goats and options.game_version: MAP_PATCH
   - name: Castle Sansa - Goatling Near Library
     code: 76
     region: Castle Main
-    rule:
     can_create:
       randomize_goats and options.game_version: MAP_PATCH
   - name: Sansa Keep - Furniture-less Goatling
     code: 77
     region: Keep Main
-    rule:
     can_create:
       randomize_goats: true
   - name: Sansa Keep - Distorted Goatling
     code: 78
     region: Keep (Northeast) => Castle
-    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - 20 Bean Casserole Goatling
     code: 79
     region: Castle => Theatre (Front)
-    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - Theatre Goer Goatling 1
     code: 80
     region: Castle => Theatre (Front)
-    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - Theatre Goer Goatling 2
     code: 81
     region: Castle => Theatre (Front)
-    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - Theatre Manager Goatling
     code: 82
     region: Castle => Theatre (Front)
-    rule:
     can_create:
       randomize_goats: true
   - name: Twilight Theatre - Murderous Goatling
@@ -884,85 +842,71 @@ locations:
   - name: Castle Sansa - Stool Near Crystal 1
     code: 85
     region: Castle Main
-    rule:
     can_create:
       randomize_chairs: true
   - name: Castle Sansa - Stool Near Crystal 2
     code: 86
     region: Castle Main
-    rule:
     can_create:
       randomize_chairs: true
   - name: Castle Sansa - Stool Near Crystal 3
     code: 87
     region: Castle Main
-    rule:
     can_create:
       randomize_chairs: true
   - name: Castle Sansa - Gazebo Stool
     code: 88
     region: Castle Main
-    rule:
     can_create:
       randomize_chairs: true
   - name: Sansa Keep - Distorted Stool
     code: 89
     region: Keep (Northeast) => Castle
-    rule:
     can_create:
       randomize_chairs: true
   - name: Sansa Keep - Path to Throne Stool
     code: 90
     region: Keep Throne Room
-    rule:
     can_create:
       randomize_chairs: true
   - name: Sansa Keep - The Throne
     code: 91
     region: Keep Throne Room
-    rule:
     can_create:
       randomize_chairs: true
   - name: Listless Library - Hay Bale Near Entrance
     code: 92
     region: Library Main
-    rule:
     can_create:
       randomize_chairs: true
   - name: Listless Library - Hay Bale Near Eggs
     code: 93
     region: Library Top
-    rule:
     can_create:
       randomize_chairs: true
   - name: Listless Library - Hay Bale in the Back
     code: 94
     region: Library Back
-    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stool Near Bookcase
     code: 95
     region: Theatre Outside Scythe Corridor
-    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stool Around a Table 1
     code: 96
     region: Theatre Outside Scythe Corridor
-    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stool Around a Table 2
     code: 97
     region: Theatre Outside Scythe Corridor
-    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stool Around a Table 3
     code: 98
     region: Theatre Outside Scythe Corridor
-    rule:
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stage Left Stool
@@ -981,86 +925,72 @@ locations:
   - name: Listless Library - A Book About a Princess
     code: 101
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Cooking
     code: 102
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book Full of Plays
     code: 103
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Reading
     code: 104
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Aquatic Life
     code: 105
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Jester
     code: 106
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Loss
     code: 107
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book on Musical Theory
     code: 108
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Girl
     code: 109
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Thimble
     code: 110
     region: Library Main
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Monster
     code: 111
     region: Library Greaves
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About Revenge
     code: 112
     region: Library Greaves
-    rule:
     can_create:
       randomize_books: true
   - name: Listless Library - A Book About a Restaurant
     code: 113
     region: Library Top
-    rule:
     can_create:
       randomize_books: true
 
   - name: Listless Library - Note Near Eggs
     code: 114
     region: Library Top
-    rule:
     can_create:
       randomize_notes: true
   - name: The Underbelly - Note on a Ledge

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -107,6 +107,12 @@ ref_rules:
       options:
         game_version: full_gold
     - ref: can_slide_jump
+- name: can_gold_slide_ultra
+  rule:
+    options:
+      game_version: map_patch
+    has: slide
+    # currently this rule is only applied for high enough logic, but should be refactored to include here
 - name: can_attack
   rule:
     or:
@@ -157,7 +163,7 @@ regions:
           - ref: can_attack
           - ref: can_enter_dark_rooms
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_ultra
           has: kick
 
@@ -192,19 +198,19 @@ regions:
             has:
               cling: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           has: plunge
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           has:
             breaker: 1
             kick: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           has:
@@ -212,7 +218,7 @@ regions:
             slide_jump: 1
         - options:
             game_version: map_patch
-            difficulty: expert
+            logic_level: expert
           ref: can_attack
           has: slide
   - name: Dungeon => Castle
@@ -231,7 +237,7 @@ regions:
           - ref: can_attack
             has: kick
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           has:
@@ -239,7 +245,7 @@ regions:
             cling: 2
         - options:
             game_version: map_patch
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             slide: 1
@@ -260,11 +266,11 @@ regions:
         - has:
             kick: 3
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 4
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick_or_plunge: 2
     - region: Underbelly => Dungeon
@@ -282,7 +288,7 @@ regions:
             old_obscure: 1
           has: plunge
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
   - name: Castle Main
     exits:
@@ -301,14 +307,14 @@ regions:
         - has:
             kick_or_plunge: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has: kick
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
     - region: Castle Spiral Climb
       rule:
@@ -319,23 +325,23 @@ regions:
             cling: 2
             plunge: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick_or_plunge: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             slide_jump: 1
             plunge: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_ultra
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick_or_plunge: 1
@@ -359,25 +365,25 @@ regions:
         - ref: can_attack
           has: kick
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick_or_plunge: 3
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           ref: can_attack
           has: slide_jump
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_slide_ultra
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick_or_plunge: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick: 2
     - region: Castle By Scythe Corridor
@@ -386,7 +392,7 @@ regions:
         - has:
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick_or_plunge: 4
   - name: Castle High Climb
@@ -402,7 +408,7 @@ regions:
             kick: 4
             plunge: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick: 3
     - region: Castle High Climb
@@ -420,20 +426,20 @@ regions:
             plunge: 1
             slide_jump: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick: 3
             breaker: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick: 1
             plunge: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick_or_plunge: 2
     - region: Castle => Theatre (Front)
@@ -443,16 +449,16 @@ regions:
             cling: 4
             kick_or_plunge: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 6
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_ultra
           has:
             kick: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick_or_plunge: 3
@@ -469,15 +475,15 @@ regions:
         - has:
             kick: 4
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_slide_ultra
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick: 3
     - region: Castle Moon Room
@@ -489,11 +495,11 @@ regions:
             slide_jump: 1
             kick_or_plunge: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick: 4
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
     - region: Theatre Main
       rule:
@@ -504,14 +510,14 @@ regions:
         - has:
             kick: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick: 4  # TODO double check for hard logic
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_slide_ultra
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick_or_plunge: 1
@@ -537,20 +543,20 @@ regions:
             kick: 1
             plunge: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 4
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           has:
             kick_or_plunge: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has: plunge
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
     - region: Castle Main
       rule:
@@ -568,11 +574,11 @@ regions:
         - has:
             kick: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           ref: can_attack
           has: kick
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
   - name: Library Top
     exits:
@@ -589,21 +595,21 @@ regions:
             kick: 3
             light: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick: 3
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick: 2
             plunge: 1
             light: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick: 2
   - name: Library Back
@@ -624,14 +630,14 @@ regions:
         - has:
             kick: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has: kick
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
   - name: Keep Main
     exits:
@@ -651,7 +657,7 @@ regions:
             cling: 2
             kick: 1
         - options:
-            difficulty: hard
+            logic_level: hard
       # Note for trackers: This is accessible with nothing but not in logic.
       # Cutting the platform or hitting the lever make this harder and are irreversible.
       # On Hard and above, the player is expected to not do either.
@@ -663,7 +669,7 @@ regions:
            # See "Keep Main -> Keep Locked Room".
            # All other methods would go through Keep Locked Room instead.
         - options:
-            difficulty: hard
+            logic_level: hard
     - region: Keep Throne Room
       rule:
         or:
@@ -685,7 +691,7 @@ regions:
             light: 1
             kick_or_plunge: 4
         - options:
-            difficulty: hard
+            logic_level: hard
           and:
           - has:
               breaker: 1
@@ -698,41 +704,41 @@ regions:
                 old_obscure: 1
               has: kick
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             breaker: 1
             plunge: 1
             kick: 4
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             light: 1
             kick: 3
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             cling: 4
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             cling: 2
             kick: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             cling: 2
             slide: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             light: 1
             kick_or_plunge: 3
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             slide: 1
@@ -744,7 +750,7 @@ regions:
         - has:
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
     - region: Theatre Outside Scythe Corridor
       rule:
@@ -758,7 +764,7 @@ regions:
             old_obscure: 1
           has: plunge  # TODO: this doesn't really matter right now but is a little questionable for normal
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
     - region: Keep (Northeast) => Castle
       rule:
@@ -769,10 +775,10 @@ regions:
             kick: 2
         - has: plunge
         - options:
-            difficulty: hard
+            logic_level: hard
           has: kick
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
     - region: Castle Main
   - name: Keep Locked Room
@@ -803,14 +809,14 @@ regions:
           tags:
             old_obscure: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has: plunge
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
     - region: Castle Main
     - region: Theatre Pillar => Bailey
@@ -839,19 +845,19 @@ regions:
               tags:
                 old_obscure: 1
         - options:
-            difficulty: hard
+            logic_level: hard
             game_version: map_patch
           has:
             kick_or_plunge: 3
         - options:
-            difficulty: hard
+            logic_level: hard
             game_version: map_patch
           has:
             kick: 2
             light: 1
         - options:
             game_version: map_patch
-            difficulty: expert
+            logic_level: expert
           and:
           - has: slide
           - or:
@@ -861,7 +867,7 @@ regions:
                 cling: 2
         - options:
             game_version: full_gold
-            difficulty: expert
+            logic_level: expert
           has: slide
 
   - name: Tower Remains
@@ -874,22 +880,22 @@ regions:
             cling: 2
             kick_or_plunge: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           ref: can_attack
           has:
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_ultra
           has:
             kick: 1
@@ -917,11 +923,11 @@ regions:
               old_obscure: 1
           - ref: can_attack
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick: 1
             slide: 1
@@ -935,18 +941,18 @@ regions:
         - has:
             kick_or_plunge: 4
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick: 3
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_ultra
           has:
             kick: 1
             plunge: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             plunge: 1
             kick: 2
@@ -965,31 +971,31 @@ regions:
               tags:
                 old_obscure: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           ref: can_attack
           has:
             kick: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           has:
             plunge: 1
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             plunge: 1
             kick: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_attack
           has:
             slide: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_ultra
           has:
             kick: 3
@@ -1008,12 +1014,12 @@ regions:
             kick: 1
             slide_jump: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick: 1
             slide: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick: 1
             plunge: 1
@@ -1030,7 +1036,7 @@ regions:
             - has: slide_jump
             - ref: can_attack
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             plunge: 1
             cling: 4
@@ -1041,12 +1047,12 @@ regions:
             slide: 1
             plunge: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             slide: 1
             kick: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
     - region: Underbelly Main Upper
       rule:
@@ -1058,36 +1064,36 @@ regions:
               plunge: 1
               kick: 2
           - options:
-              difficulty: hard
+              logic_level: hard
             has:
               plunge: 1
               kick: 1
           - options:
-              difficulty: hard
+              logic_level: hard
             has:
               plunge: 1
               cling: 4
           - options:
-              difficulty: hard
+              logic_level: hard
             has:
               kick: 2
               cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick: 1
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             cling: 4
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_slide_ultra
           has:
             kick: 1
@@ -1112,40 +1118,40 @@ regions:
                 cling: 2
                 kick: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           has:
             breaker: 1
             cling: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             slide_jump: 1
             kick: 1
             plunge: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             slide: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             kick: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick_or_plunge: 3
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             cling: 6
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_ultra
           has:
             kick_or_plunge: 2
@@ -1164,30 +1170,30 @@ regions:
               cling: 2
               kick: 2
           - options:
-              difficulty: hard
+              logic_level: hard
             has: light
           - options:
-              difficulty: hard
+              logic_level: hard
             has:
               cling: 2
               kick_or_plunge: 1
           - options:
-              difficulty: hard
+              logic_level: hard
             has:
               kick_or_plunge: 4
           - options:
-              difficulty: hard
+              logic_level: hard
             tags:
               old_obscure: 1
             has:
               cling:4
           - options:
-              difficulty: expert
+              logic_level: expert
             has:
               slide: 1
               kick: 2
           - options:
-              difficulty: expert
+              logic_level: expert
             has:
               kick: 3
   - name: Underbelly By Heliacal
@@ -1209,30 +1215,30 @@ regions:
             plunge: 1
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has: plunge
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             slide: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             breaker: 1
             kick: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             cling: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick: 2
@@ -1247,11 +1253,11 @@ regions:
             plunge: 1
             kick: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick: 3
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             slide_jump: 1
             kick: 1
@@ -1265,7 +1271,7 @@ regions:
         - tags:
             old_obscure: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 2
   - name: Underbelly => Keep
@@ -1289,12 +1295,12 @@ regions:
               slide_jump: 1
               kick: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             plunge: 1
             kick: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             plunge: 1
             cling: 4
@@ -1311,7 +1317,7 @@ regions:
         - has:
             cling: 6
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 4
     - region: Theatre Pillar
@@ -1330,7 +1336,7 @@ regions:
         - has:
             cling: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has: kick
     - region: Castle => Theatre (Front)
       rule:
@@ -1340,7 +1346,7 @@ regions:
         - has: kick
         - has: slide_jump
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
   - name: Theatre Pillar => Bailey
     exits:
@@ -1354,40 +1360,40 @@ regions:
             kick: 1
             light: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             slide_jump: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             cling: 2
     - region: Bailey Lower
   - name: Castle => Theatre Pillar
     exits:
     - region: Theatre Pillar
-      or:
-      - rule:
-          has: plunge
-      - options:
-          difficulty: hard
-        has: slide_jump
-      - options:
-          difficulty: expert
-        has: kick
-      - options:
-          difficulty: expert
-        has:
-          cling: 2
-      - options:
-          difficulty: expert
-        has: slide
+      rule:
+        or:
+        - has: plunge
+        - options:
+            logic_level: hard
+          has: slide_jump
+        - options:
+            logic_level: expert
+          has: kick
+        - options:
+            logic_level: expert
+          has:
+            cling: 2
+        - options:
+            logic_level: expert
+          has: slide
     - region: Castle Main
   - name: Theatre Pillar
     exits:
@@ -1400,12 +1406,12 @@ regions:
             plunge: 1
             kick: 3
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             slide_jump: 1
             kick_or_plunge: 3
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick_or_plunge: 3
@@ -1423,7 +1429,7 @@ regions:
             cling: 6
             slide_jump: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 4
     - region: Dungeon Escape Upper
@@ -1439,7 +1445,7 @@ regions:
             old_obscure: 1
           has: plunge
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_enter_darkrooms
           has: slide
     - region: Keep Main
@@ -1454,7 +1460,7 @@ regions:
             old_obscure: 1
           has: plunge
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
   - name: The Great Door
 
@@ -1510,36 +1516,36 @@ locations:
           kick: 1
           light: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 6
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 1
           light: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           slide_jump: 1
           plunge: 1
           light: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 3
           plunge: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         ref: can_gold_slide_ultra
         has: kick
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           light: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick: 2
@@ -1559,22 +1565,22 @@ locations:
         tags:
           old_obscure: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         tags:
           old_obscure: 1
         has:
           slide_jump: 1
           kick: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick: 1
@@ -1591,29 +1597,29 @@ locations:
         tags:
           old_obscure: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 6
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 1
           plunge: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 1
           light: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           kick_or_plunge: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         ref: can_gold_ultra
         has: kick_or_plunge
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           light: 1
           cling: 2
@@ -1646,16 +1652,16 @@ locations:
             kick: 3
       - options:
           game_version: map_patch
-          difficulty: expert
+          logic_level: expert
         has: slide
       - options:
           game_version: full_gold
-          difficulty: expert
+          logic_level: expert
         has:
           cling: 2
       - options:
           game_version: full_gold
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick: 1
@@ -1676,7 +1682,7 @@ locations:
         tags:
           old_obscure: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: Castle Sansa - Balcony
     code: 10
@@ -1691,21 +1697,21 @@ locations:
           slide_jump: 1
           kick_or_plunge: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           slide_jump: 1
           kick: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           kick: 3
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           plunge: 1
           kick: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: Castle Sansa - Corner Corridor
     code: 11
@@ -1717,11 +1723,11 @@ locations:
       - has:
           kick: 4
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 3
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           kick: 2
           slide: 1
@@ -1744,38 +1750,38 @@ locations:
         tags:
           old_obscure: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick_or_plunge: 4
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
           plunge: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 4
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           light: 1
           slide: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         ref: can_gold_ultra
         has: kick
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick_or_plunge: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           kick: 3
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           cling: 2
 
@@ -1797,10 +1803,10 @@ locations:
       - has:
           kick: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has: kick_or_plunge
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: Castle Sansa - Tall Room Near Wheel Crawlers
     code: 15
@@ -1813,21 +1819,21 @@ locations:
       - has:
           kick: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has: kick
       - options:
-          difficulty: hard
+          logic_level: hard
         tags:
           old_obscure: 1
         has:
           slide_jump: 1
           plunge: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         ref: can_gold_ultra
   - name: Castle Sansa - Wheel Crawlers
     code: 16
@@ -1846,18 +1852,18 @@ locations:
         tags:
           old_obscure: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has: kick
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           slide_jump: 1
           plunge: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has: kick_or_plunge
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: Castle Sansa - High Climb From Courtyard
     code: 17
@@ -1872,25 +1878,25 @@ locations:
       - has: kick
         ref: can_attack
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 6
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           plunge: 1
           slide_jump: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         ref: can_attack
         has: kick
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           cling: 2
           kick: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: Castle Sansa - Alcove Near Scythe Corridor
     code: 18
@@ -1904,30 +1910,30 @@ locations:
       - has:
           kick_or_plunge: 4
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 4
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           plunge: 1
           cling: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 2
           plunge: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           kick_or_plunge: 3
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         ref: can_gold_ultra
         has: plunge
   - name: Castle Sansa - Near Theatre Front
@@ -1941,24 +1947,24 @@ locations:
           kick: 2
           plunge: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 6
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
           kick: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         ref: can_gold_slide_ultra
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           cling: 4
 
@@ -1980,13 +1986,13 @@ locations:
         - has:
             kick: 3
         - options:
-            difficulty: hard
+            logic_level: hard
           has: kick
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
         - options:
-            difficulty: expert
+            logic_level: expert
           has: plunge
   - name: Sansa Keep - Alcove Near Locked Door
     code: 21
@@ -2008,7 +2014,7 @@ locations:
       - has:
           cling: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: Sansa Keep - Sunsetter
     code: 25
@@ -2035,11 +2041,11 @@ locations:
       - has:
           kick_or_plunge: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 4
       - options:
-          difficulty: expert
+          logic_level: expert
           has: slide
   - name: Listless Library - Locked Door Across
     code: 28
@@ -2051,11 +2057,11 @@ locations:
       - has: kick
       - has: slide_jump
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick_or_plunge: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: Listless Library - Locked Door Left
     code: 29
@@ -2070,15 +2076,15 @@ locations:
       - has:
           kick_or_plunge: 3
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           kick_or_plunge: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick_or_plunge: 1
@@ -2095,10 +2101,10 @@ locations:
         - has:
             cling: 2
         - options:
-            difficulty: hard
+            logic_level: hard
           has: slide_jump
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
   - name: Twilight Theatre - Back Of Auditorium
     code: 31
@@ -2112,10 +2118,10 @@ locations:
       - has:
           cling: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has: slide_jump
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: Twilight Theatre - Center Stage
     code: 32
@@ -2128,14 +2134,14 @@ locations:
           plunge: 1
           slide_jump: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cutter: 1
           cling: 6
           kick_or_plunge: 1
           slide_jump: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           cutter: 1
           cling: 4
@@ -2149,11 +2155,11 @@ locations:
         - has: light
         - has: kick
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             cling: 4
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
   - name: Twilight Theatre - Tucked Behind Boxes
     code: 34
@@ -2174,26 +2180,26 @@ locations:
       - has:
           kick: 4
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
           kick_or_plunge: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
           slide_jump: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           kick: 3
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick_or_plunge: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           cling: 2
@@ -2212,15 +2218,15 @@ locations:
       - has:
           kick: 4
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 2
           breaker: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has: kick
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: Empty Bailey - Cheese Bell
     code: 38
@@ -2233,15 +2239,15 @@ locations:
           cling: 2
           kick_or_plunge: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 3
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 6
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick: 1
@@ -2251,7 +2257,7 @@ locations:
     rule:
       or:
       - and:
-        - can_reach_region: upper_bailey
+        # - can_reach_region: upper_bailey  # TODO refactor/implement this
         - or:
           - has:
               cling: 2
@@ -2288,16 +2294,16 @@ locations:
           kick: 3
           slide_jump: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 3
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 2
           slide_jump: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           kick: 1
           slide: 1
@@ -2310,14 +2316,14 @@ locations:
       - has:
           kick: 3
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has: kick
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: The Underbelly - Locked Door
     code: 44
@@ -2341,13 +2347,13 @@ locations:
         - has:
             kick: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has: slide_jump
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
       - options:
-          difficulty: expert
+          logic_level: expert
         has: kick
   - name: The Underbelly - Rafters Near Keep
     code: 46
@@ -2359,14 +2365,14 @@ locations:
           kick: 2
       - has: light
       - options:
-          difficulty: hard
+          logic_level: hard
         has: kick_or_plunge
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
   - name: The Underbelly - Strikebreak Wall
     code: 47
@@ -2380,24 +2386,24 @@ locations:
             light: 1
             kick_or_plunge: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           has: light
         - options:
-            difficulty: hard
+            logic_level: hard
           has:
             kick_or_plunge: 3
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             kick: 1
             plunge: 1
         - options:
-            difficulty: expert
+            logic_level: expert
           has:
             slide: 1
             kick: 2
         - options:
-            difficulty: expert
+            logic_level: expert
           ref: can_gold_ultra
           has:
             cling: 2
@@ -2419,17 +2425,17 @@ locations:
             tags:
               old_obscure: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           plunge: 1
           cling: 6
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           cutter: 1
           slide: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           slide: 1
           kick: 1
@@ -2443,11 +2449,11 @@ locations:
       - has:
           kick_or_plunge: 2  # climb the right tower and cross
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
     can_create:
       split_cling_gem: false
@@ -2590,11 +2596,11 @@ locations:
       - has:
           kick_or_plunge: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
     can_create:
       split_cling_gem: true
@@ -2606,11 +2612,11 @@ locations:
       - has:
           kick_or_plunge: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
     can_create:
       split_cling_gem: true
@@ -2622,11 +2628,11 @@ locations:
       - has:
           kick_or_plunge: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
     can_create:
       split_cling_gem: true
@@ -2686,14 +2692,14 @@ locations:
           - tags:
               old_obscure: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has: kick
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 2
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
     can_create:
       randomize_goats: true
@@ -2764,7 +2770,7 @@ locations:
       - has:
           cling: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has: kick
     can_create:
       randomize_goats: true
@@ -2875,12 +2881,12 @@ locations:
           tags:
             old_obscure: 1
         - options:
-            difficulty: hard
+            logic_level: hard
           tags:
             old_obscure: 1
           has: slide_jump
         - options:
-            difficulty: expert
+            logic_level: expert
           has: slide
     can_create:
       randomize_chairs: true
@@ -2967,10 +2973,10 @@ locations:
           cling: 2
       - has: light
       - options:
-          difficulty: hard
+          logic_level: hard
         has: slide_jump
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
     can_create:
       randomize_notes: true
@@ -2986,19 +2992,19 @@ locations:
           kick: 2
           slide_jump: 1
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           kick_or_plunge: 2
       - options:
-          difficulty: hard
+          logic_level: hard
         has:
           cling: 6
           kick: 1
       - options:
-          difficulty: expert
+          logic_level: expert
         has: slide
       - options:
-          difficulty: expert
+          logic_level: expert
         has:
           cling: 6
     can_create:

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -196,11 +196,11 @@ def check_options(player_options: PseudoregaliaOptions, options: OptionData | No
 class PseudoregaliaRule(Rule[PseudoregaliaWorld], game="Pseudoregalia"):
     rule: Rule
     tags: dict[str, int] | None
-    options: OptionData | None
+    option_data: OptionData | None
 
     def __init__(self, rule_data: RuleData, ref_rules: dict[str, "PseudoregaliaRule"]):
         self.tags = rule_data.tags
-        self.options = rule_data.options
+        self.option_data = rule_data.options
 
         if rule_data.and_ is not None:
             self.rule = And(*(PseudoregaliaRule(child_rule_data, ref_rules) for child_rule_data in rule_data.and_))
@@ -220,7 +220,7 @@ class PseudoregaliaRule(Rule[PseudoregaliaWorld], game="Pseudoregalia"):
 
     @override
     def _instantiate(self, world: PseudoregaliaWorld) -> Rule.Resolved:
-        passes_filter = check_tags(world.tags) and check_options(world.options)
+        passes_filter = check_tags(world.tags, self.tags) and check_options(world.options, self.option_data)
         return self.rule.resolve(world) if passes_filter else False_().resolve(world)
 
 def create_entrance_name(start: str, end: str, entrance_name: str | None) -> str:


### PR DESCRIPTION
mostly boilerplate, but with these additions we should only need to add the relevant rules (and tags when we need them for writing said rules) and we should have a usable v1 for rulebuilder-enhanced logic

can_create rules might need some tweaking, but should be a decent baseline and might just be fine as-is

will likely work on it more soon, but wanted the baseline out as I started work on it