### PR TITLE
Update Linux install instructions

### DIFF
--- a/AP_Randomizer/apworld/docs/setup_en.md
+++ b/AP_Randomizer/apworld/docs/setup_en.md
@@ -70,8 +70,10 @@ Just ignore anything that is Steam Deck specific or that doesn't apply to you.
    then go to Pseudoregalia_AP folder and select `pseudoregalia.exe`.
 5. Open Properties. You will need to change:
     * `Shortcut` > `Launch Options` > Copy in `WINEDLLOVERRIDES="dwmapi=n,b" %command%`
-    * `Compatibility` > Check `Force the use of a specific Steam Play compatibility tool` > Select `Proton 8.0-5` in the dropdown.
-    * (Optional) `Shortcut` > The field at the top that is by default `pseudoregalia.exe` to something more distinct (Necessary for having multiple Non-Steam Games with the same .exe name).
+    * `Compatibility` > Check `Force the use of a specific Steam Play compatibility tool`
+      > Select `Proton 8.0-5` in the dropdown.
+    * (Optional) `Shortcut` > The field at the top that is by default `pseudoregalia.exe` to something more distinct
+      (Necessary for having multiple Non-Steam Games with the same .exe name).
 6. Lastly, Pseudoregalia utilizes Visual C++ Runtime 2022.
     1. Download Protontricks if you have not already. This is located within Discovery.
     2. Launch Protontricks, and select Non-Steam Shortcut: pseudoregalia.exe.

--- a/AP_Randomizer/apworld/docs/setup_en.md
+++ b/AP_Randomizer/apworld/docs/setup_en.md
@@ -77,7 +77,8 @@ Just ignore anything that is Steam Deck specific or that doesn't apply to you.
     2. Launch Protontricks, and select Non-Steam Shortcut: pseudoregalia.exe.
     3. Select the default wineprefix > install a Windows DLL or component > scroll down and select vcrun2022.
     4. Wait and follow the prompts until it has installed twice.
-    5. You can go through this process twice if you are unsure, when you scroll down to vcrun2022 again, it should already be checked. It has installed correctly.
+    5. You can go through this process twice if you are unsure,
+       when you scroll down to vcrun2022 again, it should already be checked. It has installed correctly.
 7. Launch in Game Mode which should open Pseudoregalia. Select a new file.
 8. Enter the connect info and select Start. You will need to edit your controls to include show keyboard.
 

--- a/AP_Randomizer/apworld/docs/setup_en.md
+++ b/AP_Randomizer/apworld/docs/setup_en.md
@@ -68,16 +68,16 @@ Just ignore anything that is Steam Deck specific or that doesn't apply to you.
    You should notice no change to the root folder, but the mod files will be added to the subfolders.
 4. Open the Steam Client, Add a Non-Steam Game,
    then go to Pseudoregalia_AP folder and select `pseudoregalia.exe`.
-5. Open Properties, then ensure that you check compatibility to Force Proton Experimental.
-    * If Experimental doesn't work, try a different version (8.0-5 was verified to work)
+5. Open Properties. You will need to change:
+    * `Shortcut` > `Launch Options` > Copy in `WINEDLLOVERRIDES="dwmapi=n,b" %command%`
+    * `Compatibility` > Check `Force the use of a specific Steam Play compatibility tool` > Select `Proton 8.0-5` in the dropdown.
+    * (Optional) `Shortcut` > The field at the top that is by default `pseudoregalia.exe` to something more distinct (Necessary for having multiple Non-Steam Games with the same .exe name).
 6. Lastly, Pseudoregalia utilizes Visual C++ Runtime 2022.
-   Download Protontricks if you have not already.
-   This is located within Discovery.
-   After launching Protontricks, select Non-Steam Shortcut: pseudoregalia.exe.
-   Select the default wineprefix, install a Windows DLL or component, then scroll down and select vcrun2022.
-   Wait and follow the prompts until it has installed twice.
-   You can go through this process twice if you are unsure.
-   When you scroll down to vcrun2022 again, it should already be checked. It has installed correctly.
+    1. Download Protontricks if you have not already. This is located within Discovery.
+    2. Launch Protontricks, and select Non-Steam Shortcut: pseudoregalia.exe.
+    3. Select the default wineprefix > install a Windows DLL or component > scroll down and select vcrun2022.
+    4. Wait and follow the prompts until it has installed twice.
+    5. You can go through this process twice if you are unsure, when you scroll down to vcrun2022 again, it should already be checked. It has installed correctly.
 7. Launch in Game Mode which should open Pseudoregalia. Select a new file.
 8. Enter the connect info and select Start. You will need to edit your controls to include show keyboard.
 


### PR DESCRIPTION
Without `WINEDLLOVERRIDE`, proton will use it's own version of `dwmapi.dll` to save on resources having to run it through the translation layer. This .dll is used by UE4SS as it's entry point, so we just need to ensure it's using the provided version.

Also sectioned out the Protontricks instructions so it comes out more readable in the github markdown viewer.