### PR TITLE
Rule builder style fixes

### DIFF
--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -1,15 +1,14 @@
 from typing import Any
 
-from worlds.AutoWorld import World, WebWorld
-from BaseClasses import Location, Region, CollectionState, Tutorial
+from BaseClasses import CollectionState, Location, Region, Tutorial
+from worlds.AutoWorld import WebWorld, World
 
-from .items import PseudoregaliaItem, item_table, item_groups
-from .options import PseudoregaliaOptions
 from .constants.difficulties import EXPERT, LUNATIC
 from .constants.versions import FULL_GOLD
-from .logic import ItemMappingData, pseudoregalia_data, player_start_enum
-from .rules import create_rules, check_options
-
+from .items import PseudoregaliaItem, item_groups, item_table
+from .logic import ItemMappingData, player_start_enum, pseudoregalia_data
+from .options import PseudoregaliaOptions
+from .rules import check_options, create_rules
 
 pseudoregalia_rules = create_rules(pseudoregalia_data)
 spawn_point_regions = {player_start_enum[data.player_start]: data.region for data in pseudoregalia_data.spawn_points}

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -51,7 +51,7 @@ class PseudoregaliaWorld(World):
 
     game = "Pseudoregalia"
     required_client_version = (0, 7, 0)
- 
+
     item_name_to_id = {name: data.code for name, data in item_table.items() if data.code is not None}
     location_name_to_id = {data.name: data.code for data in pseudoregalia_data.locations if data.code is not None}
     item_name_groups = item_groups

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -6,7 +6,7 @@ from worlds.AutoWorld import WebWorld, World
 from .constants.difficulties import EXPERT, LUNATIC
 from .constants.versions import FULL_GOLD
 from .items import PseudoregaliaItem, item_groups, item_table
-from .logic import ItemMappingData, player_start_enum, pseudoregalia_data
+from .logic import player_start_enum, pseudoregalia_data
 from .options import PseudoregaliaOptions
 from .rules import check_options, create_rules
 
@@ -83,7 +83,7 @@ class PseudoregaliaWorld(World):
                 return {mapping[index]: 1}
         elif not mapping.first_only or state.count(item.name, self.player) == 0:
             count = mapping.count if mapping.count is not None else 1
-            return {name: count for name in mapping.names}
+            return dict.fromkeys(mapping.names, count)
         return {}
 
     def create_key_hints(self) -> Any:

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -157,7 +157,8 @@ class PseudoregaliaWorld(World):
         for region_data in pseudoregalia_data.regions:
             self.multiworld.regions.append(Region(region_data.name, self.player, self.multiworld))
 
-        locations = sorted(pseudoregalia_data.locations, key=lambda loc_data: zones.index(loc_data.name.split(" - ")[0]))
+        locations = sorted(pseudoregalia_data.locations,
+                           key=lambda loc_data: zones.index(loc_data.name.split(" - ")[0]))
         for loc_data in locations:
             if not check_options(self.options, loc_data.can_create):
                 continue

--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -17,6 +17,7 @@ spawn_point_regions = {player_start_enum[data.player_start]: data.region for dat
 class PseudoregaliaLocation(Location):
     game = "Pseudoregalia"
 
+
 zones = (
     "Dilapidated Dungeon",
     "Castle Sansa",

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -225,7 +225,9 @@ item_groups: dict[str, set[str]] = {
     "pogo": {"Ascendant Light"},
     "floof": {"Professionalism"},
     "heliacal power": {"Air Kick"},
-    "aspects": {"Indignation",  # some nice to have groups when sorting local/non local items in yaml etc, does not include "Memento" aka new map powerup
+    # some nice to have groups when sorting local/non local items in yaml etc,
+    # does not include "Memento" aka new map powerup
+    "aspects": {"Indignation",
                 "Aerial Finesse",
                 "Pilgrimage",
                 "Empathy",

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -27,6 +27,7 @@ def precollect_if_theatre_start(precollect_if_normal: bool) -> Callable[[Pseudor
         return 1 if is_theatre_start and matches_difficulty else 0
     return precollect
 
+
 precollect_if_theatre_start_normal = precollect_if_theatre_start(True)
 precollect_if_theatre_start_hard_plus = precollect_if_theatre_start(False)
 
@@ -248,16 +249,16 @@ item_groups: dict[str, set[str]] = {
                  "Cling Gem"},
     "collectables": {"Health Piece",
                      "Small Key"},
-    #"weapon": {"Dream Breaker",
-    #           "Progressive Dream Breaker",
-    #           "Strikebreak",
-    #           "Soul Cutter"},
-    #"attire": {"Professional", # Castle Sansa trial
-    #           "Soldier", # Empty Bailey trial
-    #           "Guardian", # Sansa Keep trial
-    #           "Sol Sister", # Dilapidated Dungeon trial
-    #           "Classy", # Twilight Theatre trial
-    #           "XIX", # Underbelly trial
-    #           "Sleepytime", # Listless Library trial
-    #           "Bleeding Heart}, # Tower Remains trial
+    # "weapon": {"Dream Breaker",
+    #            "Progressive Dream Breaker",
+    #            "Strikebreak",
+    #            "Soul Cutter"},
+    # "attire": {"Professional", # Castle Sansa trial
+    #            "Soldier", # Empty Bailey trial
+    #            "Guardian", # Sansa Keep trial
+    #            "Sol Sister", # Dilapidated Dungeon trial
+    #            "Classy", # Twilight Theatre trial
+    #            "XIX", # Underbelly trial
+    #            "Sleepytime", # Listless Library trial
+    #            "Bleeding Heart}, # Tower Remains trial
 }

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -1,5 +1,6 @@
 from BaseClasses import Item, ItemClassification
-from typing import NamedTuple, Dict, Set, Callable
+from typing import NamedTuple
+from collections.abc import Callable
 from .constants.versions import MAP_PATCH
 from .options import PseudoregaliaOptions
 
@@ -28,7 +29,7 @@ precollect_if_theatre_start_normal = precollect_if_theatre_start(True)
 precollect_if_theatre_start_hard_plus = precollect_if_theatre_start(False)
 
 
-item_table: Dict[str, PseudoregaliaItemData] = {
+item_table: dict[str, PseudoregaliaItemData] = {
     "Dream Breaker": PseudoregaliaItemData(
         code=1,
         classification=ItemClassification.progression,
@@ -208,7 +209,7 @@ item_table: Dict[str, PseudoregaliaItemData] = {
         classification=ItemClassification.progression),
 }
 
-item_groups: Dict[str, Set[str]] = {
+item_groups: dict[str, set[str]] = {
     "major keys": {"Major Key - Empty Bailey",
                    "Major Key - The Underbelly",
                    "Major Key - Tower Remains",
@@ -254,5 +255,5 @@ item_groups: Dict[str, Set[str]] = {
     #           "Classy", # Twilight Theatre trial
     #           "XIX", # Underbelly trial
     #           "Sleepytime", # Listless Library trial
-    #           "Bleeding Heart}, # Tower Remains trial  
+    #           "Bleeding Heart}, # Tower Remains trial
 }

--- a/AP_Randomizer/apworld/items.py
+++ b/AP_Randomizer/apworld/items.py
@@ -1,6 +1,8 @@
-from BaseClasses import Item, ItemClassification
-from typing import NamedTuple
 from collections.abc import Callable
+from typing import NamedTuple
+
+from BaseClasses import Item, ItemClassification
+
 from .constants.versions import MAP_PATCH
 from .options import PseudoregaliaOptions
 

--- a/AP_Randomizer/apworld/logic.py
+++ b/AP_Randomizer/apworld/logic.py
@@ -53,6 +53,7 @@ class PseudoregaliaData:
     completion_rule: RuleData
     """Defines the completion condition for the world."""
 
+
 @dataclass
 class ItemMappingData:
     names: list[str]
@@ -61,6 +62,7 @@ class ItemMappingData:
     """The amount of the pseudo item that one of this item maps to. None defaults to 1."""
     first_only: bool | None
     """Whether only the first of the item contributes to the pseudo item. None defaults to False."""
+
 
 @dataclass
 class TagData:
@@ -83,6 +85,7 @@ class TagData:
     lunatic: str | None
     """Description for what the tag does at logic level 4."""
 
+
 @dataclass
 class TagGroupData:
     name: str
@@ -92,10 +95,12 @@ class TagGroupData:
     children: list[str]
     """A list of tags and tag groups that are children of this tag group."""
 
+
 @dataclass
 class RefRuleData:
     name: str
     rule: RuleData
+
 
 @dataclass
 class RegionData:
@@ -104,10 +109,12 @@ class RegionData:
     exits: list[ExitData] | None
     """A list of all entrances starting from this region."""
 
+
 @dataclass
 class Enums:
     player_start: list[str]
     """Lists all player starts in the game, including game start, save points and transitions."""
+
 
 @dataclass
 class SpawnPointData:
@@ -122,6 +129,7 @@ class SpawnPointData:
     Whether this spawn point should be used as the default in the SpawnPoint option. At most one spawn point can be
     marked as default.
     """
+
 
 @dataclass
 class LocationData:
@@ -138,6 +146,7 @@ class LocationData:
     """Provides a set of options to determined whether the location should be created."""
     event_item: str | None
     """Name of the event item to lock to this location. Must reference a progression item with no code."""
+
 
 @dataclass
 class RuleData:
@@ -169,7 +178,9 @@ class RuleData:
     options: OptionData | None
     """Provides additional filtering based on other options."""
 
+
 TagLevel: TypeAlias = Literal["advanced", "hard", "expert", "lunatic"]
+
 
 @dataclass
 class ExitData:
@@ -179,6 +190,7 @@ class ExitData:
     """Overrides the default entrance name. If None, the default of '{from} -> {to}' is used."""
     rule: RuleData | None
     """The rule for this entrance."""
+
 
 OptionData: TypeAlias = dict[str, bool | str]
 """

--- a/AP_Randomizer/apworld/logic.py
+++ b/AP_Randomizer/apworld/logic.py
@@ -12,7 +12,7 @@ class PseudoregaliaData:
     """
     Defines how to map progression items to pseudo items in world collect and remove functions. All keys must match the
     name of a progression item.
-    
+
     A str value is a simple mapping, so one of this item maps to one of the pseudo item.
     A list[str] value is for progressive items: the first of this item maps to the pseudo item at index 0, the second
       maps to the pseudo item at index 1, etc.
@@ -24,7 +24,7 @@ class PseudoregaliaData:
     tag_groups: list[TagGroupData]
     """
     Defines groups that bundle tags together to help make customization simpler.
-    
+
     Entries in this list can contain tags as well as other tag groups as children. Child relationships should not form
     cycles, so groups should only reference other groups as children that are defined above them in the list. In other
     words, this list should be sorted from less general to more general.
@@ -32,7 +32,7 @@ class PseudoregaliaData:
     ref_rules: list[RefRuleData]
     """
     Defines some common rules that can be referenced in any other rule.
-    
+
     Entries in this list can even reference each other, but they should not form cycles. To validate this, references in
     this list can only refer to rules defined above them.
     """
@@ -154,7 +154,7 @@ class RuleData:
     has: str | list[str] | dict[str, int] | None
     """
     Maps to the Has, HasAll, or HasAllCounts RuleBuilder objects depending on the type.
-    
+
     All string values in this type must be the name of a progression item or a pseudo item defined in item_mapping.
     """
     can_reach_region: str | None

--- a/AP_Randomizer/apworld/logic.py
+++ b/AP_Randomizer/apworld/logic.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
-from dataclasses import dataclass
+
 import pkgutil
+from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias
+
 import yaml
 
 from .dacite import Config, from_dict
+
 
 @dataclass
 class PseudoregaliaData:

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
-from Options import Toggle, Choice, DefaultOnToggle, PerGameCommonOptions
-from .constants.difficulties import NORMAL, HARD, EXPERT, LUNATIC
-from .constants.versions import MAP_PATCH, FULL_GOLD
-from .logic import pseudoregalia_data, player_start_enum
+
+from Options import Choice, DefaultOnToggle, PerGameCommonOptions, Toggle
+
+from .constants.difficulties import EXPERT, HARD, LUNATIC, NORMAL
+from .constants.versions import FULL_GOLD, MAP_PATCH
+from .logic import player_start_enum, pseudoregalia_data
 
 
 class LogicLevel(Choice):

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -188,4 +188,3 @@ class PseudoregaliaOptions(PerGameCommonOptions):
     randomize_books: RandomizeBooks
     randomize_notes: RandomizeNotes
     major_key_hints: MajorKeyHints
-

--- a/AP_Randomizer/apworld/options.py
+++ b/AP_Randomizer/apworld/options.py
@@ -25,7 +25,8 @@ class LogicLevel(Choice):
 
 class ObscureLogic(Toggle):
     """
-    Enables logic for obscure knowledge and creative pathing that isn't difficult to execute but may not be obvious or commonly known.
+    Enables logic for obscure knowledge and creative pathing that isn't difficult to execute
+    but may not be obvious or commonly known.
     This option is forced on if logic level is set to Expert or Lunatic.
     """
     display_name = "Obscure Logic"
@@ -84,7 +85,8 @@ class SplitClingGem(Toggle):
 
 class GameVersion(Choice):
     """
-    The version of Pseudoregalia you will use when playing the game. Different versions have different logic, locations, and items.
+    The version of Pseudoregalia you will use when playing the game.
+    Different versions have different logic, locations, and items.
     After you connect, the game will warn you if the version you are playing doesn't match this option.
 
     map_patch: The latest version of the game. Includes time trials and new outfits.

--- a/AP_Randomizer/apworld/ruff.toml
+++ b/AP_Randomizer/apworld/ruff.toml
@@ -1,0 +1,22 @@
+line-length = 120
+indent-width = 4
+target-version = "py311"
+extend-exclude = ["dacite"]
+
+[lint]
+select = ["B", "C", "E", "F", "W", "I", "N", "Q", "UP", "RET", "RSE", "RUF", "ISC", "PLC", "PLE", "PLW", "T20", "PERF"]
+ignore = [
+# these come from ap's ruff file, but none are applicable to psedo rn
+#    "B011",  # In AP, the use of assert False is essential because we optimise out these statements for release builds.
+#    "C901",  # Author disagrees with limiting branch complexity
+#    "N818",  # Author agrees with this rule, but Core AP violates this and changing it would be a hassle.
+#    "PLC0415",  # In AP, we consider local imports totally fine & necessary
+#    "PLC1802",  # Author agrees with this rule, but it literally changes the functionality of the code, which is unsafe.
+#    "PLC1901",  # This is just not equivalent
+#    "PLE1141",  # Gives false positives when the dict keys are tuples, but does not mention this in the suggested fix.
+#    "UP015",  # Explicit is better than implicit, so we'd prefer to keep "r" in open() calls.
+
+
+    "RUF012",  # annoying to manage all the mutable classvars required in ap
+#    "I001",  # import sorting, just annoying to see while fixing other things
+]

--- a/AP_Randomizer/apworld/ruff.toml
+++ b/AP_Randomizer/apworld/ruff.toml
@@ -18,5 +18,6 @@ ignore = [
 
 
     "RUF012",  # annoying to manage all the mutable classvars required in ap
+    "RET505",  # in no way is the visual distinction that they are exclusive elifs worse performance or something
 #    "I001",  # import sorting, just annoying to see while fixing other things
 ]

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -16,10 +16,13 @@ else:
 def check_tags(player_tags: dict[str, int], tags: dict[str, int] | None) -> bool:
     return tags is None or all(level <= player_tags[tag] for tag, level in tags.items())
 
+
 def check_options(player_options: PseudoregaliaOptions, options: OptionData | None) -> bool:
     return options is None or all(getattr(player_options, op_name) == value for op_name, value in options.items())
 
+
 tag_level_to_int = {level: i+1 for i, level in enumerate(get_args(TagLevel))}
+
 
 class PseudoregaliaRule(Rule[PseudoregaliaWorld], game="Pseudoregalia"):
     rule: Rule
@@ -63,8 +66,10 @@ class PseudoregaliaRule(Rule[PseudoregaliaWorld], game="Pseudoregalia"):
         passes_filter = check_tags(world.tags, self.tags) and check_options(world.options, self.option_data)
         return self.rule.resolve(world) if passes_filter else False_().resolve(world)
 
+
 def create_entrance_name(start: str, end: str, entrance_name: str | None) -> str:
     return entrance_name if entrance_name is not None else f"{start} -> {end}"
+
 
 @dataclass
 class PseudoregaliaRules:
@@ -75,6 +80,7 @@ class PseudoregaliaRules:
     def get_entrance_rule(self, start: str, end: str, entrance_name: str | None) -> PseudoregaliaRule | None:
         """Helper to resolve entrance name and get rule if it exists."""
         return self.entrance_rules.get(create_entrance_name(start, end, entrance_name))
+
 
 def create_rules(pseudoregalia_data: PseudoregaliaData) -> PseudoregaliaRules:
     ref_rules: dict[str, PseudoregaliaRule] = {}

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, get_args
+
+from rule_builder.rules import And, CanReachRegion, False_, Has, HasAll, HasAllCounts, Or, Rule, True_
 from typing_extensions import override
 
-from rule_builder.rules import Rule, And, Or, Has, HasAll, HasAllCounts, CanReachRegion, True_, False_
-
-from .logic import OptionData, RuleData, PseudoregaliaData, TagLevel
+from .logic import OptionData, PseudoregaliaData, RuleData, TagLevel
 from .options import PseudoregaliaOptions
 
 if TYPE_CHECKING:

--- a/AP_Randomizer/apworld/test/bases.py
+++ b/AP_Randomizer/apworld/test/bases.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass, field
-from test.bases import WorldTestBase
-import yaml
 
+import yaml
 from Fill import fast_fill
+
+from test.bases import WorldTestBase
 
 from .. import PseudoregaliaWorld
 from ..logic import PseudoregaliaData, data_from_dict, pseudoregalia_data

--- a/AP_Randomizer/apworld/test/bases.py
+++ b/AP_Randomizer/apworld/test/bases.py
@@ -41,7 +41,7 @@ class PseudoKeyHintsBase(PseudoTestBase):
                 for location in locations
             ]
             assert slot_data["key_hints"] == expected_key_hints, \
-                   f"Expected {expected_key_hints} but found {slot_data["key_hints"]}"
+                   f"Expected {expected_key_hints} but found {slot_data['key_hints']}"
         else:
             assert "key_hints" not in slot_data, "Expected no key_hints in slot_data"
 
@@ -73,5 +73,6 @@ class PseudoValidationBase(PseudoTestBase):
                 validator = Validator()
                 validator.validate_data(data)
                 num_errors = len(validator.errors)
+                nl = "\n"  # py<3.12 escape characters didn't work in fstrings ig
                 assert case_data.expected_errors == num_errors, \
-                    f"expected {case_data.expected_errors} errors, got {num_errors}\n{"\n".join(validator.errors)}"
+                    f"expected {case_data.expected_errors} errors, got {num_errors}{nl}{nl.join(validator.errors)}"

--- a/AP_Randomizer/apworld/test/test_validate.py
+++ b/AP_Randomizer/apworld/test/test_validate.py
@@ -139,7 +139,7 @@ class TestValidationTagGroups(PseudoValidationBase):
                 children: [tag_group_2]
               - name: tag_group_2
                 description: another tag group
-                children: [tag]            
+                children: [tag]
             """,
             expected_errors=1,
         ),

--- a/AP_Randomizer/apworld/test/test_validate.py
+++ b/AP_Randomizer/apworld/test/test_validate.py
@@ -407,7 +407,7 @@ class TestValidationLocations(PseudoValidationBase):
                 region: Fake Region
             """,
             expected_errors=1,
-        ),        
+        ),
         "non progression event item": PseudoValidationBase.Case(
             data="""
             regions:
@@ -429,7 +429,7 @@ class TestValidationLocations(PseudoValidationBase):
                 event_item: Slide
             """,
             expected_errors=1,
-        ),        
+        ),
         # TODO: validate checks in location rules?
         # TODO: validate can_create options?
     }

--- a/AP_Randomizer/apworld/validate.py
+++ b/AP_Randomizer/apworld/validate.py
@@ -30,6 +30,7 @@ from .rules import create_entrance_name
 # escape quotes?? probably not necessary but would be "correct"
 # r"^[a-zA-Z_][a-zA-Z0-9_]*$"u
 
+
 class Validator:
     def validation_context(*, context_type: Literal["start", "key", "index"], key: str | None = None):
         """

--- a/AP_Randomizer/apworld/validate.py
+++ b/AP_Randomizer/apworld/validate.py
@@ -1,12 +1,26 @@
 from __future__ import annotations
+
 from typing import Literal
 
 from BaseClasses import ItemClassification
 from Options import Choice, Toggle
 
 from .items import item_table
-from .logic import Enums, ExitData, ItemMappingData, LocationData, OptionData, PseudoregaliaData, RefRuleData, \
-    RegionData, RuleData, SpawnPointData, TagGroupData, TagData, TagLevel
+from .logic import (
+    Enums,
+    ExitData,
+    ItemMappingData,
+    LocationData,
+    OptionData,
+    PseudoregaliaData,
+    RefRuleData,
+    RegionData,
+    RuleData,
+    SpawnPointData,
+    TagData,
+    TagGroupData,
+    TagLevel,
+)
 from .options import PseudoregaliaOptions
 from .rules import create_entrance_name
 

--- a/AP_Randomizer/apworld/validate.py
+++ b/AP_Randomizer/apworld/validate.py
@@ -229,7 +229,7 @@ class Validator:
     @validation_context(context_type="index")
     def validate_region_exit(self, index: int, region_name: str, exit_data: ExitData):
         self.validate_region_exit_region(exit_data.region)
-        entrance_name = create_entrance_name(region_name, exit_data.region, exit_data.entrance_name)            
+        entrance_name = create_entrance_name(region_name, exit_data.region, exit_data.entrance_name)
         self.validate_region_exit_entrance_name(entrance_name)
         if exit_data.rule is not None:
             self.validate_rule(exit_data.rule)

--- a/AP_Randomizer/apworld/validate.py
+++ b/AP_Randomizer/apworld/validate.py
@@ -21,10 +21,10 @@ class Validator:
         """
         Manages the path for validation errors. Keeping track of the path helps to describe exactly where in the data
         the error occured.
-        
+
         Context type `"start"` should be used only at the start of validation. Context type `"key"` should be used when
         descending into an object. Context type `"index"` should be used when descending into an array.
-        
+
         If `context_type="key"` and `key=None` or if `context_type="index"`, the first argument after the validator will
         be added to the path and should be a `str` or `int` respectively.
         """


### PR DESCRIPTION
just running through 
```
python -m pycodestyle --max-line-length=120 .
python -m ruff check .
```
and applying reasonable changes
(its like 90% whitespace, typing, and import styling)

i also included the ruff config which is mostly the ap one but modified to ignore dacite and the rule around mutable class attributes because it's so annoying to manage in ap 