### PR TITLE
logic

### DIFF
--- a/AP_Randomizer/apworld/__init__.py
+++ b/AP_Randomizer/apworld/__init__.py
@@ -201,9 +201,8 @@ class PseudoregaliaWorld(World):
         slot_data = {
             "apworld_version": self.world_version,
             "game_version": self.options.game_version.value,
-            "logic_level": self.options.logic_level.value,
+            "tags": {tag: level for tag, level in self.tags.items() if level},
             "spawn_point": self.options.spawn_point.value,
-            "obscure_logic": bool(self.options.obscure_logic),
             "progressive_breaker": bool(self.options.progressive_breaker),
             "progressive_slide": bool(self.options.progressive_slide),
             "split_sun_greaves": bool(self.options.split_sun_greaves),

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -358,9 +358,15 @@ regions:
               tags:
                 logic_level: expert
             - has:
-                kick: 3
-              tags:
-                logic_level: lunatic
+                kick_or_plunge: 3
+              or:
+                # expert needs AL to get to the first bubble
+                - ref: can_bounce
+                  tags:
+                    logic_level: expert
+                # lunatic can use the bubble in the previous room
+                - tags:
+                    logic_level: lunatic
   - name: Castle High Climb
   - name: Castle By Scythe Corridor
     exits:
@@ -376,6 +382,11 @@ regions:
                 kick: 3
               tags:
                 logic_level: hard
+            - has:
+                kick: 2
+                plunge: 1
+              tags:
+                logic_level: expert
       - region: Castle High Climb
         rule:
           or:
@@ -839,6 +850,16 @@ regions:
                     game_version: full_gold
               tags:
                 logic_level: expert
+            - has:
+                cling: 2
+                kick: 1
+              or:
+                - tags:
+                    logic_level: expert
+                  options:
+                    game_version: full_gold
+                - tags:
+                    logic_level: lunatic
             - ref: can_slide_jump
               has: plunge
               tags:
@@ -874,11 +895,7 @@ regions:
               has: [kick, plunge]
               tags:
                 logic_level: expert
-            - ref: can_gold_ultra
-              has: kick
-              tags:
-                logic_level: lunatic
-            - has: [slide, kick, plunge]
+            - has: [slide, kick]
               tags:
                 logic_level: lunatic
             - has:
@@ -1252,13 +1269,21 @@ regions:
       - region: Theatre Outside Scythe Corridor
         rule:
           or:
-            # TODO: routes with bounce
             - has:
                 cling: 6
             - has:
                 cling: 4
               tags:
                 logic_level: hard
+            - ref: can_bounce
+              has:
+                kick_or_plunge: 3
+              tags:
+                logic_level: expert
+            - ref: can_bounce
+              has: [slide, kick]
+              tags:
+                logic_level: expert
       - region: Theatre Pillar
         rule:
           or:
@@ -1369,6 +1394,15 @@ regions:
                 cling: 4
               tags:
                 logic_level: hard
+            - ref: can_bounce
+              has:
+                kick_or_plunge: 3
+              tags:
+                logic_level: expert
+            - ref: can_bounce
+              has: [slide, kick]
+              tags:
+                logic_level: expert
       - region: Dungeon Escape Upper
         rule:
           ref: can_enter_dark_rooms
@@ -1542,9 +1576,23 @@ locations:
             logic_level: expert
         - has:
             slide: 1
+            cling: 4
+          tags:
+            logic_level: expert
+        - has:
+            slide: 1
+            kick: 1
+            cling: 2
+          tags:
+            logic_level: expert
+        - has:
+            slide: 1
             kick: 2
           tags:
             logic_level: expert
+        - has: [slide, kick, plunge]
+          tags:
+            logic_level: lunatic
   - name: Dilapidated Dungeon - Past Poles
     code: 5
     region: Dungeon Strong Eyes
@@ -1604,12 +1652,15 @@ locations:
           ref: can_bounce
           tags:
             logic_level: hard
-        - has:
-            kick_or_plunge: 2
+        - has: [kick, plunge]
           tags:
             logic_level: expert
         - ref: can_gold_ultra
           has: kick_or_plunge
+          tags:
+            logic_level: expert
+        - has:
+            cling: 4
           tags:
             logic_level: expert
         - ref: can_bounce
@@ -1617,6 +1668,10 @@ locations:
             cling: 2
           tags:
             logic_level: expert
+        - has:
+            kick: 2
+          tags:
+            logic_level: lunatic
         - ref: can_gold_ultra
           tags:
             logic_level: lunatic
@@ -1842,6 +1897,9 @@ locations:
           tags:
             logic_level: hard
             old_obscure: advanced
+        - has: plunge
+          tags:
+            logic_level: expert
         - ref: can_gold_ultra
           tags:
             logic_level: expert
@@ -1931,6 +1989,12 @@ locations:
           tags:
             logic_level: hard
         - has:
+            cling: 2
+            kick: 1
+          tags:
+            logic_level: hard
+            old_obscure: advanced
+        - has:
             kick_or_plunge: 3
           tags:
             logic_level: expert
@@ -1941,6 +2005,10 @@ locations:
           has: plunge
           tags:
             logic_level: expert
+        - has:
+            cling: 2
+          tags:
+            logic_level: lunatic
   - name: Castle Sansa - Near Theatre Front
     code: 19
     region: Castle Moon Room
@@ -2056,6 +2124,10 @@ locations:
           tags:
             logic_level: hard
         - has: slide
+          tags:
+            logic_level: expert
+        - has:
+            cling: 2
           tags:
             logic_level: expert
         - has: plunge
@@ -2237,7 +2309,7 @@ locations:
   - name: Empty Bailey - Cheese Bell
     code: 38
     region: Bailey Upper
-    rule: # TODO consider to/from center steeple
+    rule:
       or:
         - has:
             kick: 4
@@ -2255,6 +2327,14 @@ locations:
         - has: [slide, kick]
           tags:
             logic_level: expert
+        - has:
+            slide: 1
+            cling: 2
+          tags:
+            logic_level: expert
+        - has: slide
+          tags:
+            logic_level: lunatic
   - name: Empty Bailey - Guarded Hand
     code: 39
     region: Bailey Lower
@@ -2419,6 +2499,12 @@ locations:
         - has:
             plunge: 1
             cling: 6
+          tags:
+            logic_level: hard
+        - has:
+            kick: 1
+            plunge: 1
+            cling: 4
           tags:
             logic_level: hard
         - ref: can_soul_cutter
@@ -2807,8 +2893,14 @@ locations:
     code: 99
     region: Theatre Main
     rule:
-      has:
-        cling: 4
+      or:
+        - has:
+            cling: 4
+        - has:
+            cling: 2
+            kick: 1
+          tags:
+            logic_level: expert
     can_create:
       randomize_chairs: true
   - name: Twilight Theatre - Stage Right Stool

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -2349,7 +2349,7 @@ locations:
             cling: 2
           tags:
             logic_level: expert
-        - has: slide
+        - has: slide # chained slide ultra from center steeple
           tags:
             logic_level: lunatic
   - name: Empty Bailey - Guarded Hand

--- a/AP_Randomizer/apworld/logic.yaml
+++ b/AP_Randomizer/apworld/logic.yaml
@@ -805,11 +805,27 @@ regions:
             - ref: can_bounce
               tags:
                 logic_level: lunatic
+      - region: Bailey Guarded Hand
+        rule:
+          has: breaker
+          or:
+            - has: plunge
+            - has:
+                kick: 2
       - region: Castle Main
       - region: Theatre Pillar => Bailey
   - name: Bailey Upper
     exits:
       - region: Bailey Lower
+      - region: Bailey Guarded Hand
+        rule:
+          or:
+            - has:
+                cling: 2
+            - has:
+                kick: 3
+            - tags:
+                old_obscure: advanced
       - region: Underbelly => Bailey
         rule:
           has: plunge
@@ -866,6 +882,7 @@ regions:
                 logic_level: lunatic
               options:
                 game_version: map_patch
+  - name: Bailey Guarded Hand
 
   - name: Tower Remains
     exits:
@@ -2337,22 +2354,7 @@ locations:
             logic_level: lunatic
   - name: Empty Bailey - Guarded Hand
     code: 39
-    region: Bailey Lower
-    rule:
-      or:
-        - can_reach_region: Bailey Upper
-          or:
-            - has:
-                cling: 2
-            - has:
-                kick: 3
-            - tags:
-                old_obscure: advanced
-        - has: breaker
-          or:
-            - has: plunge
-            - has:
-                kick: 2
+    region: Bailey Guarded Hand
   - name: Empty Bailey - Inside Building
     code: 40
     region: Bailey Lower

--- a/AP_Randomizer/src/Client.cpp
+++ b/AP_Randomizer/src/Client.cpp
@@ -132,7 +132,7 @@ namespace Client {
                     if (key == "key_hints") {
                         ParseKeyHints(iter.value());
                     }
-                    else if (key == "apworld_version") {
+                    else if (key == "apworld_version" || key == "tags") {
                         continue;
                     }
                     else {


### PR DESCRIPTION
this PR adds a collection of clauses that come from player suggestions (or me). in most cases where it comes from a player, I'll link to where it was suggested, tho sources may be missing on some (sorry). I also updated slot data to prepare for granular logic.

clauses:

* `Castle Spiral Climb -> Castle By Scythe Corridor`
  * added `3 kick_or_plunge + can_bounce` to expert; bounce helps get to the first bubble, difficult but possible to get from the first to the second with `3 kick` or `2 kick + plunge`. [source (discord)](https://discord.com/channels/731205301247803413/1529789118354034749/1537991802911461426)
  * added `2 kick + plunge` to lunatic (it was just `3 kick` previously).
* `Castle By Scythe Corridor -> Castle Spiral Climb`: added `2 kick + plunge` to expert; `3 kick` was already in hard, but replacing one kick with sunsetter requires a tight turnaround sunsetter flip.
* `Bailey Upper -> Tower Remains`: added `2 cling + kick` to full gold expert and lunatic. in full gold, the broken pillar at the bottom of the tower is much higher, which makes the start of the tower climb easier. map patch requires a cling jump with a really good skid jump to make it, which is why it's in lunatic. crossing the gaps in the bridge either requires cling jump speed or a first person trick (which actually makes crossing with only 1 kick possible).
* `Tower Remains -> The Great Door`: changed `slide + plunge + kick` to `slide + kick` in lunatic. the jump isn't really that bad, you just need a good coyote ultra to make it around the turn. removed the `can_gold_ultra + kick` rule from lunatic as it was made superfluous by the new rule
* `Theatre Main -> Theatre Outside Scythe Corridor`: added `can_bounce + 3 kick_or_plunge` and `can_bounce + slide + kick` to expert. getting through the scythe corridor is pretty easy with just bounce and 1 kick just by riding the top ones, and the other items are for getting the rest of the way. you can use slide + 1 kick to get through the room right behind the stage by going over the barriers
* `Theatre Outside Scythe Corridor -> Theatre Main`: added `can_bounce + 3 kick_or_plunge` and `can_bounce + slide + kick` to expert. same reasoning as the opposite entrance
* `Dilapidated Dungeon - Dark Orbs`: added `slide + 4 cling` and `slide + kick + 2 cling` to expert and `slide + kick + plunge` to lunatic. adds some combinations with less than 6 cling (which is currently a hard rule). the lunatic clause either requires first person on the sunsetter flip or is made much easier by it. [source (github issue)](https://github.com/pseudoregalia-modding/pseudoregalia-archipelago/issues/45)
* `Dilapidated Dungeon - Rafters`
  * moved `2 kick` from expert to lunatic. the method I found requires a glitchy ledge grab into a truly devious reverse kick. if there is an easier method I missed it could stay in expert. worth considering whether these glitchy ledge grabs should be in logic, tho I'm inclined to say yes. [source (discord)](https://discord.com/channels/731205301247803413/1529789118354034749/1535459080611831851)
  * added `4 cling` to expert. requires a little trickery to get on the door frame with only 4 cling. [source (discord)](https://discord.com/channels/731205301247803413/1147564210436452393/1522097339823685735)
* `Castle Sansa - Tall Room Near Wheel Crawlers`: added `plunge` to expert. requires turnaround sunsetter flips, normal stand on pole with sunsetter, and the crouch backflip sunsetter tech. [source (youtube)](https://youtu.be/F-gnbxDxO0w)
* `Castle Sansa - Alcove Near Scythe Corridor`: added `2 cling + kick` to hard + obscure and `2 cling` to lunatic. the idea is using the door frame to make getting over with cling easier. obscure because of abusing the door frame. the kick in hard helps with both getting to the door frame and actually getting to the check. 2 cling is in lunatic because getting on the door frame is a little awkward, and similar clauses are in lunatic elsewhere. [source (discord)](https://discord.com/channels/731205301247803413/1147564210436452393/1485329653278179581)
* `Listless Library - Upper Back`: added `can_attack + 2 cling` to expert. it's honestly not that bad and could maybe even be in hard. [source (discord)](https://discord.com/channels/731205301247803413/1529789118354034749/1536174118976880640)
* `Empty Bailey - Cheese Bell`: added `slide + 2 cling` to expert and `slide` to lunatic. expert clause was one of those missed when adding split cling since `6 cling` is in hard. [source (youtube)](https://youtu.be/27GOGrElgGg?t=188)
* `The Underbelly - Surrounded By Holes`: added `kick + plunge + 4 cling` to hard. variation on the `plunge + 6 cling` clause that goes along the right wall.
* `Twilight Theatre - Stage Left Stool`: added `kick + 2 cling` to expert. [source (youtube)](https://youtu.be/bZ4FmKkQ8bc?si=DjwoXnDeBEcukL6D)

that last video has some more potential clauses around theatre key but they involve soulcutter-less stage right, which I wanna take some more time to consider

this PR also removes `logic_level` and `obscure_logic` from slot data and adds `tags`. this is a change we'd have to make anyway with granular logic, and doing it now means we won't have to bump minor version again with that update. **note:** I'm pretty sure with this change the 0.11.0 client I gave you previously will crash with this apworld, so let me know if you want another build