### PR TITLE
add str/repr dunder methods to make debugging easier

### DIFF
--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -66,6 +66,14 @@ class PseudoregaliaRule(Rule[PseudoregaliaWorld], game="Pseudoregalia"):
         passes_filter = check_tags(world.tags, self.tags) and check_options(world.options, self.option_data)
         return self.rule.resolve(world) if passes_filter else False_().resolve(world)
 
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        if not self.tags and not self.option_data:
+            return str(self.rule)
+        return f"PseudoregaliaRule({self.rule}, tags={self.tags}, option_data={self.option_data})"
+
 
 def create_entrance_name(start: str, end: str, entrance_name: str | None) -> str:
     return entrance_name if entrance_name is not None else f"{start} -> {end}"

--- a/AP_Randomizer/apworld/rules.py
+++ b/AP_Randomizer/apworld/rules.py
@@ -72,6 +72,10 @@ class PseudoregaliaRule(Rule[PseudoregaliaWorld], game="Pseudoregalia"):
     def __str__(self):
         if not self.tags and not self.option_data:
             return str(self.rule)
+        if not self.tags:
+            return f"PseudoregaliaRule({self.rule}, option_data={self.option_data})"
+        if not self.option_data:
+            return f"PseudoregaliaRule({self.rule}, tags={self.tags})"
         return f"PseudoregaliaRule({self.rule}, tags={self.tags}, option_data={self.option_data})"
 
 


### PR DESCRIPTION
add str/repr dunder methods to make debugging easier

tested by 
```py
from worlds.pseudoregalia import pseudoregalia_rules as rs
print(rs.entrance_rules["Castle Spiral Climb -> Castle By Scythe Corridor"])
```
`Or(HasAllCounts(cling x2), PseudoregaliaRule(HasAllCounts(kick_or_plunge x4), tags={'logic_level': 3}, option_data=None), PseudoregaliaRule(HasAllCounts(kick x3), tags={'logic_level': 4}, option_data=None))
`